### PR TITLE
feat(tags): add chain view - plain HTML tag selection

### DIFF
--- a/src/lib/components/icon.svelte
+++ b/src/lib/components/icon.svelte
@@ -109,7 +109,6 @@
 		sun: IconSun,
 		settings: IconSettings,
 		share: IconShare,
-		link: IconShare,
 		shuffle: IconShuffle,
 		'sidebar-fill-right': IconSidebarFillRight,
 		signal: IconSignal,

--- a/src/lib/components/icon.svelte
+++ b/src/lib/components/icon.svelte
@@ -109,6 +109,7 @@
 		sun: IconSun,
 		settings: IconSettings,
 		share: IconShare,
+		link: IconShare,
 		shuffle: IconShuffle,
 		'sidebar-fill-right': IconSidebarFillRight,
 		signal: IconSignal,

--- a/src/lib/components/tag-chain.svelte
+++ b/src/lib/components/tag-chain.svelte
@@ -36,9 +36,16 @@
 		return branchSet
 	})
 
-	/** Filtered tags: show branches when chain has selection, otherwise show all */
+	/** Get tracks matching chain (AND logic) */
+	let matchingTracks = $derived(
+		chain.length === 0
+			? tracks
+			: tracks.filter((t) => chain.every((tag) => t.tags?.some((tTag) => tTag.toLowerCase() === tag.toLowerCase())))
+	)
+
+	/** Filtered tags: show branches when chain has selection + matching tracks, otherwise show all */
 	let visibleTags = $derived(
-		availableBranches && availableBranches.size > 0
+		chain.length > 0 && matchingTracks.length > 0 && availableBranches && availableBranches.size > 0
 			? tags.filter((t) => availableBranches.has(t.value.toLowerCase()))
 			: tags
 	)
@@ -61,13 +68,6 @@
 	function clearChain() {
 		chain = []
 	}
-
-	/** Get tracks matching chain (AND logic) */
-	let matchingTracks = $derived(
-		chain.length === 0
-			? tracks
-			: tracks.filter((t) => chain.every((tag) => t.tags?.some((tTag) => tTag.toLowerCase() === tag.toLowerCase())))
-	)
 
 	/** Play matching tracks */
 	async function playChain() {

--- a/src/lib/components/tag-chain.svelte
+++ b/src/lib/components/tag-chain.svelte
@@ -1,72 +1,67 @@
 <script lang="ts">
+	import {resolve} from '$app/paths'
 	import {setPlaylist, playTrack} from '$lib/api'
 	import {appState} from '$lib/app-state.svelte'
-	import {buildTagGraph} from '$lib/utils'
+	import {getChannelTags} from '$lib/utils'
 
-	type Tag = {value: string; count: number}
-	type Track = {id: string; tags?: string[] | null}
+	interface Tag {
+		value: string
+		count: number
+	}
 
-	/** @type {{tags: Tag[], tracks: Track[], channelSlug: string}} */
-	const {tags = [], tracks = [], channelSlug = ''} = $props()
+	interface Track {
+		id: string
+		tags?: string[] | null
+	}
+
+	interface Props {
+		tags?: Tag[]
+		tracks?: Track[]
+		channelSlug?: string
+	}
+
+	let {tags = [], tracks = [], channelSlug = ''}: Props = $props()
 
 	let chain: string[] = $state([])
 
-	/** Compute tag co-occurrence graph */
-	let tagGraph = $derived(buildTagGraph(tracks, {minEdgeWeight: 1, maxTags: 500}))
-
-	/** Get tags that co-occur with current chain (branches) */
-	let availableBranches = $derived.by((): Set<string> | null => {
-		if (chain.length === 0) return null
-
-		const branchSet = new Set<string>()
-		const chainLower = chain.map((t) => t.toLowerCase())
-
-		for (const edge of tagGraph.edges) {
-			const sourceLower = edge.source.toLowerCase()
-			const targetLower = edge.target.toLowerCase()
-
-			// If one end is in chain, add the other end
-			if (chainLower.includes(sourceLower) && !chainLower.includes(targetLower)) {
-				branchSet.add(edge.target)
-			} else if (chainLower.includes(targetLower) && !chainLower.includes(sourceLower)) {
-				branchSet.add(edge.source)
-			}
-		}
-
-		return branchSet
-	})
+	let chainLower = $derived(chain.map((t) => t.toLowerCase()))
 
 	/** Get tracks matching chain (AND logic) */
-	let matchingTracks = $derived(
-		chain.length === 0
-			? tracks
-			: tracks.filter((t) => chain.every((tag) => t.tags?.some((tTag) => tTag.toLowerCase() === tag.toLowerCase())))
-	)
+	let matchingTracks = $derived.by(() => {
+		if (chainLower.length === 0) return []
+		return tracks.filter((track) => {
+			const trackTags = (track.tags ?? []).map((tag) => tag.toLowerCase())
+			return chainLower.every((tag) => trackTags.includes(tag))
+		})
+	})
 
-	/** Filtered tags: show branches when chain has selection, filter out branches with 0 tracks */
+	/** Show only branch tags that produce >0 matches with current chain. */
 	let visibleTags = $derived.by(() => {
 		if (chain.length === 0) return tags
 
-		// If no branches, show nothing (dead end)
-		if (!availableBranches || availableBranches.size === 0) return []
+		const chainLookup = Object.fromEntries(chainLower.map((tag) => [tag, true]))
+		const branchCounts = Object.fromEntries(getChannelTags(matchingTracks).map((tag) => [tag.value, tag.count]))
 
-		// Show branches that have tracks
-		const branchTags = tags.filter((t) => availableBranches.has(t.value.toLowerCase()))
-		return branchTags
+		return tags
+			.filter((tag) => !chainLookup[tag.value.toLowerCase()])
+			.map((tag) => ({value: tag.value, count: branchCounts[tag.value.toLowerCase()] ?? 0}))
+			.filter((tag) => tag.count > 0)
 	})
 
 	/** Toggle tag in/out of chain */
-	function toggleTag(tag) {
-		if (chain.includes(tag)) {
-			chain = chain.filter((t) => t !== tag)
+	function toggleTag(tag: string) {
+		const key = tag.toLowerCase()
+		if (chainLower.includes(key)) {
+			chain = chain.filter((t) => t.toLowerCase() !== key)
 		} else {
 			chain = [...chain, tag]
 		}
 	}
 
 	/** Remove single tag from chain */
-	function removeTag(tag) {
-		chain = chain.filter((t) => t !== tag)
+	function removeTag(tag: string) {
+		const key = tag.toLowerCase()
+		chain = chain.filter((t) => t.toLowerCase() !== key)
 	}
 
 	/** Clear entire chain */
@@ -76,7 +71,7 @@
 
 	/** Play matching tracks */
 	async function playChain() {
-		if (matchingTracks.length === 0) return
+		if (chain.length === 0 || matchingTracks.length === 0) return
 		const trackIds = matchingTracks.map((t) => t.id)
 		const deckId = appState.active_deck_id
 		setPlaylist(deckId, trackIds)
@@ -97,7 +92,7 @@
 			</div>
 			<div class="chain-actions">
 				<button class="play-btn" onclick={playChain} disabled={matchingTracks.length === 0}> ▶ Play </button>
-				<a href="/{channelSlug}/tracks?tags={chain.map(encodeURIComponent).join(',')}" class="view-link">
+				<a href={resolve(`/${channelSlug}/tracks?tags=${chain.map(encodeURIComponent).join(',')}`)} class="view-link">
 					View {matchingTracks.length} tracks
 				</a>
 				<button class="clear-btn" onclick={clearChain} aria-label="Clear chain">✕</button>
@@ -108,7 +103,12 @@
 	<ol class="tag-list">
 		{#each visibleTags as { value, count } (value)}
 			<li>
-				<button type="button" class="tag-link" class:in-chain={chain.includes(value)} onclick={() => toggleTag(value)}>
+				<button
+					type="button"
+					class="tag-link"
+					class:in-chain={chainLower.includes(value.toLowerCase())}
+					onclick={() => toggleTag(value)}
+				>
 					{value}
 				</button>
 				<span class="count">{count}</span>

--- a/src/lib/components/tag-chain.svelte
+++ b/src/lib/components/tag-chain.svelte
@@ -43,12 +43,17 @@
 			: tracks.filter((t) => chain.every((tag) => t.tags?.some((tTag) => tTag.toLowerCase() === tag.toLowerCase())))
 	)
 
-	/** Filtered tags: show branches when chain has selection + matching tracks, otherwise show all */
-	let visibleTags = $derived(
-		chain.length > 0 && matchingTracks.length > 0 && availableBranches && availableBranches.size > 0
-			? tags.filter((t) => availableBranches.has(t.value.toLowerCase()))
-			: tags
-	)
+	/** Filtered tags: show branches when chain has selection, filter out branches with 0 tracks */
+	let visibleTags = $derived.by(() => {
+		if (chain.length === 0) return tags
+
+		// If no branches, show nothing (dead end)
+		if (!availableBranches || availableBranches.size === 0) return []
+
+		// Show branches that have tracks
+		const branchTags = tags.filter((t) => availableBranches.has(t.value.toLowerCase()))
+		return branchTags
+	})
 
 	/** Toggle tag in/out of chain */
 	function toggleTag(tag) {

--- a/src/lib/components/tag-chain.svelte
+++ b/src/lib/components/tag-chain.svelte
@@ -1,12 +1,47 @@
-<script>
+<script lang="ts">
 	import {setPlaylist, playTrack} from '$lib/api'
 	import {appState} from '$lib/app-state.svelte'
+	import {buildTagGraph} from '$lib/utils'
 
-	/** @type {{tags: Array<{value: string, count: number}>, tracks: Array<{id: string, tags?: string[] | null}>, channelSlug: string}} */
+	type Tag = {value: string; count: number}
+	type Track = {id: string; tags?: string[] | null}
+
+	/** @type {{tags: Tag[], tracks: Track[], channelSlug: string}} */
 	const {tags = [], tracks = [], channelSlug = ''} = $props()
 
-	/** @type {string[]} */
-	let chain = $state([])
+	let chain: string[] = $state([])
+
+	/** Compute tag co-occurrence graph */
+	let tagGraph = $derived(buildTagGraph(tracks, {minEdgeWeight: 1, maxTags: 500}))
+
+	/** Get tags that co-occur with current chain (branches) */
+	let availableBranches = $derived.by((): Set<string> | null => {
+		if (chain.length === 0) return null
+
+		const branchSet = new Set<string>()
+		const chainLower = chain.map((t) => t.toLowerCase())
+
+		for (const edge of tagGraph.edges) {
+			const sourceLower = edge.source.toLowerCase()
+			const targetLower = edge.target.toLowerCase()
+
+			// If one end is in chain, add the other end
+			if (chainLower.includes(sourceLower) && !chainLower.includes(targetLower)) {
+				branchSet.add(edge.target)
+			} else if (chainLower.includes(targetLower) && !chainLower.includes(sourceLower)) {
+				branchSet.add(edge.source)
+			}
+		}
+
+		return branchSet
+	})
+
+	/** Filtered tags: show branches when chain has selection, otherwise show all */
+	let visibleTags = $derived(
+		availableBranches && availableBranches.size > 0
+			? tags.filter((t) => availableBranches.has(t.value.toLowerCase()))
+			: tags
+	)
 
 	/** Toggle tag in/out of chain */
 	function toggleTag(tag) {
@@ -66,7 +101,7 @@
 	{/if}
 
 	<ol class="tag-list">
-		{#each tags as { value, count } (value)}
+		{#each visibleTags as { value, count } (value)}
 			<li>
 				<button type="button" class="tag-link" class:in-chain={chain.includes(value)} onclick={() => toggleTag(value)}>
 					{value}

--- a/src/lib/components/tag-chain.svelte
+++ b/src/lib/components/tag-chain.svelte
@@ -19,9 +19,10 @@
 		tracks?: Track[]
 		channelSlug?: string
 		chainTags?: string[]
+		totalCount?: number
 	}
 
-	let {tags = [], tracks = [], channelSlug = '', chainTags = $bindable([])}: Props = $props()
+	let {tags = [], tracks = [], channelSlug = '', chainTags = $bindable([]), totalCount = 0}: Props = $props()
 
 	let chainLower = $derived(chainTags.map((t) => t.toLowerCase()))
 
@@ -92,7 +93,7 @@
 			<div class="chain-actions">
 				<button class="play-btn" onclick={playChain} disabled={matchingTracks.length === 0}> ▶ Play </button>
 				<a
-					href={resolve(`/${channelSlug}/tracks?tags=${chainTags.map(encodeURIComponent).join(',')}`)}
+					href={resolve('/[slug]/tracks', {slug: channelSlug}) + `?tags=${chainTags.map(encodeURIComponent).join(',')}`}
 					class="view-link"
 				>
 					View {matchingTracks.length} tracks
@@ -113,7 +114,8 @@
 				>
 					{value}
 				</button>
-				<span class="count">{count}</span>
+				<span class="count">{count} / {totalCount}</span>
+				<span class="bar" style="--pct: {totalCount ? ((count / totalCount) * 100).toFixed(1) : '0.0'}%"></span>
 			</li>
 		{/each}
 	</ol>
@@ -223,7 +225,7 @@
 
 	.tag-list li {
 		display: flex;
-		align-items: baseline;
+		align-items: center;
 		gap: 0.5rem;
 		padding: 0.25rem 0;
 		border-bottom: 1px solid var(--gray-4);
@@ -253,8 +255,19 @@
 	}
 
 	.count {
+		flex: 0 0 auto;
 		color: var(--gray-10);
 		font-size: 0.875rem;
 		margin-left: auto;
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+	}
+
+	.bar {
+		flex: 1;
+		height: 2px;
+		background: linear-gradient(to left, var(--accent-6) var(--pct), var(--gray-7) var(--pct));
+		border-radius: 1px;
+		align-self: center;
 	}
 </style>

--- a/src/lib/components/tag-chain.svelte
+++ b/src/lib/components/tag-chain.svelte
@@ -1,0 +1,218 @@
+<script>
+	import {setPlaylist, playTrack} from '$lib/api'
+	import {appState} from '$lib/app-state.svelte'
+
+	/** @type {{tags: Array<{value: string, count: number}>, tracks: Array<{id: string, tags?: string[] | null}>, channelSlug: string}} */
+	const {tags = [], tracks = [], channelSlug = ''} = $props()
+
+	/** @type {string[]} */
+	let chain = $state([])
+
+	/** Toggle tag in/out of chain */
+	function toggleTag(tag) {
+		if (chain.includes(tag)) {
+			chain = chain.filter((t) => t !== tag)
+		} else {
+			chain = [...chain, tag]
+		}
+	}
+
+	/** Remove single tag from chain */
+	function removeTag(tag) {
+		chain = chain.filter((t) => t !== tag)
+	}
+
+	/** Clear entire chain */
+	function clearChain() {
+		chain = []
+	}
+
+	/** Get tracks matching chain (AND logic) */
+	let matchingTracks = $derived(
+		chain.length === 0
+			? tracks
+			: tracks.filter((t) => chain.every((tag) => t.tags?.some((tTag) => tTag.toLowerCase() === tag.toLowerCase())))
+	)
+
+	/** Play matching tracks */
+	async function playChain() {
+		if (matchingTracks.length === 0) return
+		const trackIds = matchingTracks.map((t) => t.id)
+		const deckId = appState.active_deck_id
+		setPlaylist(deckId, trackIds)
+		await playTrack(deckId, trackIds[0], null, 'user_click_track')
+	}
+</script>
+
+<div class="tag-chain">
+	{#if chain.length > 0}
+		<div class="chain-bar">
+			<div class="chain-tags">
+				{#each chain as tag, i (tag)}
+					{#if i > 0}<span class="sep">→</span>{/if}
+					<button class="chain-tag" onclick={() => removeTag(tag)}>
+						{tag} <span aria-hidden="true">×</span>
+					</button>
+				{/each}
+			</div>
+			<div class="chain-actions">
+				<button class="play-btn" onclick={playChain} disabled={matchingTracks.length === 0}> ▶ Play </button>
+				<a href="/{channelSlug}/tracks?tags={chain.map(encodeURIComponent).join(',')}" class="view-link">
+					View {matchingTracks.length} tracks
+				</a>
+				<button class="clear-btn" onclick={clearChain} aria-label="Clear chain">✕</button>
+			</div>
+		</div>
+	{/if}
+
+	<ol class="tag-list">
+		{#each tags as { value, count } (value)}
+			<li>
+				<button type="button" class="tag-link" class:in-chain={chain.includes(value)} onclick={() => toggleTag(value)}>
+					{value}
+				</button>
+				<span class="count">{count}</span>
+			</li>
+		{/each}
+	</ol>
+</div>
+
+<style>
+	.tag-chain {
+		margin: 0.5rem;
+	}
+
+	.chain-bar {
+		position: sticky;
+		top: 0;
+		z-index: 10;
+		background: var(--gray-5);
+		border: 1px solid var(--gray-7);
+		border-radius: var(--border-radius);
+		padding: 0.75rem;
+		margin-bottom: 1rem;
+	}
+
+	.chain-tags {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.25rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.sep {
+		color: var(--gray-9);
+		font-size: 0.875rem;
+	}
+
+	.chain-tag {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		padding: 0.25rem 0.5rem;
+		background: var(--accent-9);
+		color: var(--gray-1);
+		border: none;
+		border-radius: calc(var(--border-radius) * 999);
+		font-size: 0.875rem;
+		cursor: pointer;
+	}
+
+	.chain-tag:hover {
+		background: var(--accent-10);
+	}
+
+	.chain-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.play-btn {
+		padding: 0.375rem 0.75rem;
+		background: var(--accent-9);
+		color: var(--gray-1);
+		border: none;
+		border-radius: var(--border-radius);
+		font-size: 0.875rem;
+		cursor: pointer;
+	}
+
+	.play-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.play-btn:hover:not(:disabled) {
+		background: var(--accent-10);
+	}
+
+	.view-link {
+		font-size: 0.875rem;
+		color: var(--accent-9);
+		text-decoration: none;
+	}
+
+	.view-link:hover {
+		text-decoration: underline;
+	}
+
+	.clear-btn {
+		padding: 0.375rem 0.5rem;
+		background: transparent;
+		color: var(--gray-11);
+		border: 1px solid var(--gray-7);
+		border-radius: var(--border-radius);
+		font-size: 0.875rem;
+		cursor: pointer;
+	}
+
+	.clear-btn:hover {
+		background: var(--gray-4);
+	}
+
+	.tag-list {
+		list-style: decimal;
+		padding-left: 1.5rem;
+		margin: 0;
+	}
+
+	.tag-list li {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		padding: 0.25rem 0;
+		border-bottom: 1px solid var(--gray-4);
+	}
+
+	.tag-list li:last-child {
+		border-bottom: none;
+	}
+
+	.tag-link {
+		background: none;
+		border: none;
+		font: inherit;
+		color: var(--link-color, var(--accent-9));
+		cursor: pointer;
+		text-decoration: none;
+		padding: 0;
+	}
+
+	.tag-link:hover {
+		text-decoration: underline;
+	}
+
+	.tag-link.in-chain {
+		color: var(--accent-9);
+		font-weight: 600;
+	}
+
+	.count {
+		color: var(--gray-10);
+		font-size: 0.875rem;
+		margin-left: auto;
+	}
+</style>

--- a/src/lib/components/tag-chain.svelte
+++ b/src/lib/components/tag-chain.svelte
@@ -18,13 +18,12 @@
 		tags?: Tag[]
 		tracks?: Track[]
 		channelSlug?: string
+		chainTags?: string[]
 	}
 
-	let {tags = [], tracks = [], channelSlug = ''}: Props = $props()
+	let {tags = [], tracks = [], channelSlug = '', chainTags = $bindable([])}: Props = $props()
 
-	let chain: string[] = $state([])
-
-	let chainLower = $derived(chain.map((t) => t.toLowerCase()))
+	let chainLower = $derived(chainTags.map((t) => t.toLowerCase()))
 
 	/** Get tracks matching chain (AND logic) */
 	let matchingTracks = $derived.by(() => {
@@ -37,7 +36,7 @@
 
 	/** Show only branch tags that produce >0 matches with current chain. */
 	let visibleTags = $derived.by(() => {
-		if (chain.length === 0) return tags
+		if (chainTags.length === 0) return tags
 
 		const chainLookup = Object.fromEntries(chainLower.map((tag) => [tag, true]))
 		const branchCounts = Object.fromEntries(getChannelTags(matchingTracks).map((tag) => [tag.value, tag.count]))
@@ -52,26 +51,26 @@
 	function toggleTag(tag: string) {
 		const key = tag.toLowerCase()
 		if (chainLower.includes(key)) {
-			chain = chain.filter((t) => t.toLowerCase() !== key)
+			chainTags = chainTags.filter((t) => t.toLowerCase() !== key)
 		} else {
-			chain = [...chain, tag]
+			chainTags = [...chainTags, tag]
 		}
 	}
 
 	/** Remove single tag from chain */
 	function removeTag(tag: string) {
 		const key = tag.toLowerCase()
-		chain = chain.filter((t) => t.toLowerCase() !== key)
+		chainTags = chainTags.filter((t) => t.toLowerCase() !== key)
 	}
 
 	/** Clear entire chain */
 	function clearChain() {
-		chain = []
+		chainTags = []
 	}
 
 	/** Play matching tracks */
 	async function playChain() {
-		if (chain.length === 0 || matchingTracks.length === 0) return
+		if (chainTags.length === 0 || matchingTracks.length === 0) return
 		const trackIds = matchingTracks.map((t) => t.id)
 		const deckId = appState.active_deck_id
 		setPlaylist(deckId, trackIds)
@@ -80,10 +79,10 @@
 </script>
 
 <div class="tag-chain">
-	{#if chain.length > 0}
+	{#if chainTags.length > 0}
 		<div class="chain-bar">
 			<div class="chain-tags">
-				{#each chain as tag, i (tag)}
+				{#each chainTags as tag, i (tag)}
 					{#if i > 0}<span class="sep">→</span>{/if}
 					<button class="chain-tag" onclick={() => removeTag(tag)}>
 						{tag} <span aria-hidden="true">×</span>
@@ -92,7 +91,10 @@
 			</div>
 			<div class="chain-actions">
 				<button class="play-btn" onclick={playChain} disabled={matchingTracks.length === 0}> ▶ Play </button>
-				<a href={resolve(`/${channelSlug}/tracks?tags=${chain.map(encodeURIComponent).join(',')}`)} class="view-link">
+				<a
+					href={resolve(`/${channelSlug}/tracks?tags=${chainTags.map(encodeURIComponent).join(',')}`)}
+					class="view-link"
+				>
 					View {matchingTracks.length} tracks
 				</a>
 				<button class="clear-btn" onclick={clearChain} aria-label="Clear chain">✕</button>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -222,3 +222,96 @@ export function dedupeById<T extends {id: string | null}>(rows: T[]): T[] {
 	}
 	return [...seen.values()]
 }
+
+export interface TagGraphNode {
+	id: string
+	label: string
+	count: number
+}
+
+export interface TagGraphEdge {
+	id: string
+	source: string
+	target: string
+	weight: number
+}
+
+export interface TagGraph {
+	nodes: TagGraphNode[]
+	edges: TagGraphEdge[]
+}
+
+export interface TagGraphOptions {
+	minEdgeWeight?: number
+	maxTags?: number
+	maxEdgesPerNode?: number
+}
+
+/**
+ * Build a tag co-occurrence graph from tracks.
+ * Nodes are tags (raw strings, no `#` prefix). Edges connect tags that appear on the same track.
+ * Edge weight = number of tracks where both tags appear together.
+ */
+export function buildTagGraph(tracks: Array<{tags?: string[] | null}>, options?: TagGraphOptions): TagGraph {
+	const {minEdgeWeight = 2, maxTags = 500, maxEdgesPerNode = 20} = options ?? {}
+
+	// Count tags
+	const tagCounts: Record<string, number> = {}
+	for (const track of tracks) {
+		for (const tag of track.tags ?? []) {
+			const key = tag.toLowerCase()
+			tagCounts[key] = (tagCounts[key] || 0) + 1
+		}
+	}
+
+	// Top maxTags by count
+	const sorted = Object.entries(tagCounts)
+		.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+		.slice(0, maxTags)
+	const topTagSet = new Set(sorted.map(([t]) => t))
+
+	const nodes: TagGraphNode[] = sorted.map(([tag, count]) => ({id: tag, label: tag, count}))
+
+	// Co-occurrence edge weights
+	const edgeWeights: Record<string, number> = {}
+	for (const track of tracks) {
+		const tags = [...new Set((track.tags ?? []).map((t) => t.toLowerCase()).filter((t) => topTagSet.has(t)))]
+		for (let i = 0; i < tags.length; i++) {
+			for (let j = i + 1; j < tags.length; j++) {
+				const a = tags[i] < tags[j] ? tags[i] : tags[j]
+				const b = tags[i] < tags[j] ? tags[j] : tags[i]
+				const key = `${a}\0${b}`
+				edgeWeights[key] = (edgeWeights[key] || 0) + 1
+			}
+		}
+	}
+
+	// Filter and limit edges
+	const edgesPerNode: Record<string, number> = {}
+	const edges: TagGraphEdge[] = []
+
+	const sortedEdges = Object.entries(edgeWeights)
+		.filter(([, w]) => w >= minEdgeWeight)
+		.sort((a, b) => b[1] - a[1])
+
+	for (const [key, weight] of sortedEdges) {
+		const sep = key.indexOf('\0')
+		const source = key.slice(0, sep)
+		const target = key.slice(sep + 1)
+		if ((edgesPerNode[source] ?? 0) >= maxEdgesPerNode) continue
+		if ((edgesPerNode[target] ?? 0) >= maxEdgesPerNode) continue
+		edgesPerNode[source] = (edgesPerNode[source] ?? 0) + 1
+		edgesPerNode[target] = (edgesPerNode[target] ?? 0) + 1
+		edges.push({id: key, source, target, weight})
+	}
+
+	// Remove isolated nodes — tags with no edges after weight/count filtering
+	const connectedTags = new Set<string>()
+	for (const edge of edges) {
+		connectedTags.add(edge.source)
+		connectedTags.add(edge.target)
+	}
+	const filteredNodes = nodes.filter((n) => connectedTags.has(n.id))
+
+	return {nodes: filteredNodes, edges}
+}

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -74,7 +74,7 @@
 		alpha: () => 'A–Z'
 	}
 
-	const displayIconMap = {list: 'unordered-list', cloud: 'tag', chain: 'share-alt'}
+	const displayIconMap = {list: 'unordered-list', cloud: 'tag', chain: 'link'}
 	const displayLabelMap = {list: () => 'List', cloud: () => 'Cloud', chain: () => 'Chain'}
 
 	// Date range from tracks
@@ -225,7 +225,7 @@
 {:else}
 	<main>
 		<menu class="filtermenu">
-			<SearchInput bind:value={search} placeholder={m.tracks_filter_placeholder()} />
+			<SearchInput bind:value={search} placeholder="Search tags…" />
 
 			<PopoverMenu id="tags-data" closeOnClick={false}>
 				{#snippet trigger()}<Icon icon="filter" /><span>Data</span>{/snippet}
@@ -267,7 +267,7 @@
 						<Icon icon="tag" /><small>Cloud</small>
 					</button>
 					<button class:active={display === 'chain'} onclick={() => (display = 'chain')}>
-						<Icon icon="share-alt" /><small>Chain</small>
+						<Icon icon="link" /><small>Chain</small>
 					</button>
 				</menu>
 			</PopoverMenu>

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -26,6 +26,7 @@
 	const periodValues = ['year', 'solstice', 'month']
 	const displayValues = ['list', 'cloud', 'chain']
 	const sortValues = ['count', 'alpha']
+	const directionValues = ['desc', 'asc']
 
 	const readEnumParam = (key, validValues, fallback) => {
 		const value = page.url.searchParams.get(key)
@@ -48,13 +49,23 @@
 
 	const readSearchParam = () => page.url.searchParams.get('search') ?? ''
 
-	let filter = $state(readEnumParam('filter', filterValues, 'all'))
-	let timePeriod = $state(readEnumParam('timePeriod', periodValues, 'year'))
-	let currentPeriod = $state(readPeriodParam())
-	let display = $state(readEnumParam('display', displayValues, 'list'))
-	let sort = $state(readEnumParam('sort', sortValues, 'count'))
-	let chainTags = $state(readTagsParam())
-	let search = $state(readSearchParam())
+	let urlFilter = $derived(readEnumParam('filter', filterValues, 'all'))
+	let urlTimePeriod = $derived(readEnumParam('timePeriod', periodValues, 'year'))
+	let urlCurrentPeriod = $derived(readPeriodParam())
+	let urlDisplay = $derived(readEnumParam('display', displayValues, 'list'))
+	let urlSort = $derived(readEnumParam('sort', sortValues, 'count'))
+	let urlDirection = $derived(readEnumParam('direction', directionValues, 'desc'))
+	let urlChainTags = $derived(readTagsParam())
+	let urlSearch = $derived(readSearchParam())
+
+	let filter = $state('all')
+	let timePeriod = $state('year')
+	let currentPeriod = $state(0)
+	let display = $state('list')
+	let sort = $state('count')
+	let direction = $state('desc')
+	let chainTags = $state([])
+	let search = $state('')
 
 	const filterLabelMap = {
 		all: () => m.tags_filter_all(),
@@ -172,9 +183,11 @@
 
 		// Apply sort
 		if (sort === 'alpha') {
-			return tags.toSorted((a, b) => a.value.localeCompare(b.value))
+			const sorted = tags.toSorted((a, b) => a.value.localeCompare(b.value))
+			return direction === 'asc' ? sorted : sorted.toReversed()
 		}
-		return tags // count is already sorted from getChannelTags
+		const sorted = tags.toSorted((a, b) => b.count - a.count || a.value.localeCompare(b.value))
+		return direction === 'desc' ? sorted : sorted.toReversed()
 	})
 
 	let visibleTags = $derived.by(() => {
@@ -198,7 +211,20 @@
 		tagCount.set(visibleTags.length)
 	})
 
+	// URL is the source of truth. Keep local UI state synced when URL changes.
 	$effect(() => {
+		filter = urlFilter
+		timePeriod = urlTimePeriod
+		currentPeriod = urlCurrentPeriod
+		display = urlDisplay
+		sort = urlSort
+		direction = urlDirection
+		chainTags = urlChainTags
+		search = urlSearch
+	})
+
+	$effect(() => {
+		if (!periods.length) return
 		if (currentPeriod <= periods.length) return
 		currentPeriod = periods.length
 	})
@@ -207,6 +233,7 @@
 		const parts = []
 		if (display !== 'list') parts.push(`display=${encodeURIComponent(display)}`)
 		if (sort !== 'count') parts.push(`sort=${encodeURIComponent(sort)}`)
+		if (direction !== 'desc') parts.push(`direction=${encodeURIComponent(direction)}`)
 		if (filter !== 'all') parts.push(`filter=${encodeURIComponent(filter)}`)
 		if (timePeriod !== 'year') parts.push(`timePeriod=${encodeURIComponent(timePeriod)}`)
 		if (currentPeriod !== 0) parts.push(`period=${currentPeriod}`)
@@ -228,7 +255,7 @@
 			<SearchInput bind:value={search} placeholder="Search tags…" />
 
 			<PopoverMenu id="tags-data" closeOnClick={false}>
-				{#snippet trigger()}<Icon icon="filter" /><span>Data</span>{/snippet}
+				{#snippet trigger()}<Icon icon="filter-alt" />{filterLabelMap[filter]()}{/snippet}
 				<menu class="nav-vertical">
 					<button class:active={filter === 'all'} onclick={() => (filter = 'all')}>
 						{filterLabelMap.all()}
@@ -246,15 +273,26 @@
 			</PopoverMenu>
 
 			<PopoverMenu id="tags-order" closeOnClick={false}>
-				{#snippet trigger()}<Icon icon="sort" />{sortLabelMap[sort]()}{/snippet}
-				<menu class="nav-vertical">
-					<button class:active={sort === 'count'} onclick={() => (sort = 'count')}>
-						{sortLabelMap.count()}
+				{#snippet trigger()}
+					<Icon icon={direction === 'asc' ? 'funnel-ascending' : 'funnel-descending'} strokeWidth={1.5} />
+					{sortLabelMap[sort]()}
+				{/snippet}
+				<div class="sort-row">
+					<select bind:value={sort} aria-label={m.sort_order_label()}>
+						<option value="count">{sortLabelMap.count()}</option>
+						<option value="alpha">{sortLabelMap.alpha()}</option>
+					</select>
+					<button
+						type="button"
+						onclick={() => {
+							direction = direction === 'asc' ? 'desc' : 'asc'
+						}}
+						title={direction === 'asc' ? m.channels_tooltip_sort_asc() : m.channels_tooltip_sort_desc()}
+						aria-label={direction === 'asc' ? m.channels_tooltip_sort_asc() : m.channels_tooltip_sort_desc()}
+					>
+						<Icon icon={direction === 'asc' ? 'funnel-ascending' : 'funnel-descending'} strokeWidth={1.5} />
 					</button>
-					<button class:active={sort === 'alpha'} onclick={() => (sort = 'alpha')}>
-						{sortLabelMap.alpha()}
-					</button>
-				</menu>
+				</div>
 			</PopoverMenu>
 
 			<PopoverMenu id="tags-display" closeOnClick={false} style="margin-left: auto;">
@@ -386,6 +424,15 @@
 
 	.filtermenu :global(.search-input input) {
 		width: 100%;
+	}
+
+	.sort-row {
+		display: flex;
+		gap: 0.25rem;
+	}
+
+	.sort-row select {
+		flex: 1;
 	}
 
 	.scrubber {

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -244,35 +244,6 @@
 					</button>
 				</menu>
 				<menu class="nav-vertical">
-					<button
-						class:active={timePeriod === 'year'}
-						onclick={() => {
-							timePeriod = 'year'
-							currentPeriod = 0
-						}}
-					>
-						{periodLabelMap.year()}
-					</button>
-					<button
-						class:active={timePeriod === 'solstice'}
-						onclick={() => {
-							timePeriod = 'solstice'
-							currentPeriod = 0
-						}}
-					>
-						{periodLabelMap.solstice()}
-					</button>
-					<button
-						class:active={timePeriod === 'month'}
-						onclick={() => {
-							timePeriod = 'month'
-							currentPeriod = 0
-						}}
-					>
-						{periodLabelMap.month()}
-					</button>
-				</menu>
-				<menu class="nav-vertical">
 					<button class:active={sort === 'count'} onclick={() => (sort = 'count')}>
 						{sortLabelMap.count()}
 					</button>
@@ -300,7 +271,23 @@
 
 		{#if periods.length > 0}
 			<div class="scrubber">
-				<h3><span>{currentPeriodLabel}</span><span class="count">({Math.round(tagCount.current)})</span></h3>
+				<h3>
+					<span>{currentPeriodLabel}</span>
+					<span class="scrubber-meta">
+						<span class="count">({Math.round(tagCount.current)})</span>
+						<select
+							bind:value={timePeriod}
+							onchange={() => {
+								currentPeriod = 0
+							}}
+							aria-label={m.tags_period_label()}
+						>
+							<option value="year">{periodLabelMap.year()}</option>
+							<option value="solstice">{periodLabelMap.solstice()}</option>
+							<option value="month">{periodLabelMap.month()}</option>
+						</select>
+					</span>
+				</h3>
 				<InputRange
 					min={0}
 					max={periods.length}
@@ -414,6 +401,17 @@
 
 	.scrubber h3 .count {
 		font-variant-numeric: tabular-nums;
+	}
+
+	.scrubber .scrubber-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.scrubber .scrubber-meta select {
+		flex: 0 1 auto;
+		max-width: 100%;
 	}
 
 	.scrubber-labels {

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -6,6 +6,7 @@
 	import {channelsCollection} from '$lib/collections/channels'
 	import {getChannelTags} from '$lib/utils'
 	import InputRange from '$lib/components/input-range.svelte'
+	import TagChain from '$lib/components/tag-chain.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let slug = $derived(page.params.slug)
@@ -19,6 +20,7 @@
 	let filter = $state('all')
 	let timePeriod = $state('year')
 	let currentPeriod = $state(0)
+	let display = $state('list')
 
 	// Date range from tracks
 	let dateRange = $derived.by(() => {
@@ -157,6 +159,10 @@
 						<option value="month">{m.tags_period_months()}</option>
 					</select>
 				</label>
+				<div class="display-toggle">
+					<button class:active={display === 'list'} onclick={() => (display = 'list')} title="List"> ☰ </button>
+					<button class:active={display === 'chain'} onclick={() => (display = 'chain')} title="Chain"> ⚡ </button>
+				</div>
 			</menu>
 			<!--
 			<h1>{m.tags_heading({name: channel.name})}</h1>
@@ -196,18 +202,22 @@
 		{#if tracksQuery.isLoading}
 			<p style="margin: 1rem;">{m.channel_loading_tracks()}</p>
 		{:else if filteredTags.length > 0}
-			<ol class="list">
-				{#each filteredTags as { value, count } (value)}
-					<li>
-						<span class="tag">
-							<a href={`/search?q=@${channel.slug} ${value}`}>
-								{value}
-							</a>
-						</span>
-						<span class="count">{count}</span>
-					</li>
-				{/each}
-			</ol>
+			{#if display === 'chain'}
+				<TagChain tags={filteredTags} {tracks} channelSlug={channel.slug} />
+			{:else}
+				<ol class="list">
+					{#each filteredTags as { value, count } (value)}
+						<li>
+							<span class="tag">
+								<a href={`/search?q=@${channel.slug} ${value}`}>
+									{value}
+								</a>
+							</span>
+							<span class="count">{count}</span>
+						</li>
+					{/each}
+				</ol>
+			{/if}
 		{:else}
 			<p>{m.tags_empty()}</p>
 		{/if}
@@ -218,6 +228,31 @@
 	header {
 		margin: 0.5rem 0.5rem 0;
 		place-items: center;
+	}
+
+	.display-toggle {
+		display: flex;
+		gap: 0.25rem;
+		margin-left: auto;
+	}
+
+	.display-toggle button {
+		padding: 0.375rem 0.5rem;
+		background: var(--gray-3);
+		border: 1px solid var(--gray-7);
+		border-radius: var(--border-radius);
+		cursor: pointer;
+		font-size: 1rem;
+	}
+
+	.display-toggle button:hover {
+		background: var(--gray-4);
+	}
+
+	.display-toggle button.active {
+		background: var(--accent-9);
+		color: var(--gray-1);
+		border-color: var(--accent-9);
 	}
 
 	.scrubber {

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import {resolve} from '$app/paths'
 	import {getTracksQueryCtx} from '$lib/contexts'
 	import {Tween} from 'svelte/motion'
 	import {cubicOut} from 'svelte/easing'
@@ -9,7 +10,6 @@
 	import TagChain from '$lib/components/tag-chain.svelte'
 	import PopoverMenu from '$lib/components/popover-menu.svelte'
 	import Icon from '$lib/components/icon.svelte'
-	import {tooltip} from '$lib/components/tooltip-attachment.svelte.js'
 	import * as m from '$lib/paraglide/messages'
 
 	let slug = $derived(page.params.slug)
@@ -24,6 +24,7 @@
 	let timePeriod = $state('year')
 	let currentPeriod = $state(0)
 	let display = $state('list')
+	let sort = $state('count')
 
 	const filterLabelMap = {
 		all: () => m.tags_filter_all(),
@@ -36,6 +37,11 @@
 		year: () => m.tags_period_years(),
 		solstice: () => m.tags_period_solstices(),
 		month: () => m.tags_period_months()
+	}
+
+	const sortLabelMap = {
+		count: () => 'Count',
+		alpha: () => 'A–Z'
 	}
 
 	const displayIconMap = {list: 'unordered-list', chain: 'share-alt'}
@@ -112,52 +118,36 @@
 		return newPeriods
 	})
 
-	// Tag aggregation from track.tags
-	function aggregateTags(trackList, startDate, endDate) {
-		const filtered = trackList.filter((track) => {
-			const trackDate = new Date(track.created_at)
-			if (startDate && trackDate < startDate) return false
-			if (endDate && trackDate >= endDate) return false
-			return true
-		})
-		return getChannelTags(filtered)
-	}
-
 	// Tags for current period
-	let periodTags = $derived.by(() => {
-		if (currentPeriod === 0 || !periods.length) {
-			return aggregateTags(tracks, null, null)
-		}
+	let periodTracks = $derived.by(() => {
+		if (currentPeriod === 0 || !periods.length) return tracks
 		const period = periods[currentPeriod - 1]
-		return aggregateTags(tracks, period.startDate, period.endDate)
+		return tracks.filter((track) => {
+			const date = new Date(track.created_at)
+			return date >= period.startDate && date < period.endDate
+		})
+	})
+
+	let periodTags = $derived.by(() => {
+		return getChannelTags(periodTracks)
 	})
 
 	// Apply filter
 	let filteredTags = $derived.by(() => {
-		if (filter === 'all') return periodTags
-		if (filter === 'single-use') return periodTags.filter((t) => t.count === 1)
-		if (filter === 'frequent') return periodTags.filter((t) => t.count >= 5)
-		if (filter === 'rare') return periodTags.filter((t) => t.count >= 1 && t.count <= 4)
-		return periodTags
-	})
+		let tags = periodTags
+		if (filter === 'single-use') tags = tags.filter((t) => t.count === 1)
+		else if (filter === 'frequent') tags = tags.filter((t) => t.count >= 5)
+		else if (filter === 'rare') tags = tags.filter((t) => t.count >= 1 && t.count <= 4)
 
-	// Max count for progress bar visualization
-	let maxCount = $derived(filteredTags[0]?.count ?? 1)
+		// Apply sort
+		if (sort === 'alpha') {
+			return tags.toSorted((a, b) => a.value.localeCompare(b.value))
+		}
+		return tags // count is already sorted from getChannelTags
+	})
 
 	// Track count for current period
-	let periodTrackCount = $derived.by(() => {
-		if (currentPeriod === 0 || !periods.length) return tracks.length
-		const period = periods[currentPeriod - 1]
-		return tracks.filter((t) => {
-			const d = new Date(t.created_at)
-			return d >= period.startDate && d < period.endDate
-		}).length
-	})
-
-	// Reset period when time period changes
-	function onTimePeriodChange() {
-		currentPeriod = 0
-	}
+	let periodTrackCount = $derived(periodTracks.length)
 
 	let currentPeriodLabel = $derived(
 		currentPeriod === 0 ? m.tags_all_time() : periods[currentPeriod - 1]?.label || m.tags_all_time()
@@ -226,6 +216,18 @@
 				</menu>
 			</PopoverMenu>
 
+			<PopoverMenu id="tags-sort" closeOnClick={false}>
+				{#snippet trigger()}<Icon icon="sort-asc" /><span>{sortLabelMap[sort]()}</span>{/snippet}
+				<menu>
+					<button class:active={sort === 'count'} onclick={() => (sort = 'count')}>
+						{sortLabelMap.count()}
+					</button>
+					<button class:active={sort === 'alpha'} onclick={() => (sort = 'alpha')}>
+						{sortLabelMap.alpha()}
+					</button>
+				</menu>
+			</PopoverMenu>
+
 			<PopoverMenu id="tags-display" closeOnClick={false} style="margin-left: auto;">
 				{#snippet trigger()}<Icon icon={displayIconMap[display]} />{displayLabelMap[display]()}{/snippet}
 				<menu>
@@ -273,18 +275,21 @@
 			<p style="margin: 1rem;">{m.channel_loading_tracks()}</p>
 		{:else if filteredTags.length > 0}
 			{#if display === 'chain'}
-				<TagChain tags={filteredTags} {tracks} channelSlug={channel.slug} />
+				<TagChain tags={filteredTags} tracks={periodTracks} channelSlug={channel.slug} />
 			{:else}
 				<ol class="list">
 					{#each filteredTags as { value, count } (value)}
 						<li>
 							<span class="tag">
-								<a href={`/search?q=@${channel.slug} ${value}`}>
+								<a href={resolve(`/search?q=@${channel.slug} ${value}`)}>
 									{value}
 								</a>
 							</span>
 							<span class="count">{count} / {periodTrackCount}</span>
-							<span class="bar" style="--pct: {((count / maxCount) * 100).toFixed(1)}%"></span>
+							<span
+								class="bar"
+								style="--pct: {periodTrackCount ? ((count / periodTrackCount) * 100).toFixed(1) : '0.0'}%"
+							></span>
 						</li>
 					{/each}
 				</ol>

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -141,6 +141,19 @@
 		return periodTags
 	})
 
+	// Max count for progress bar visualization
+	let maxCount = $derived(filteredTags[0]?.count ?? 1)
+
+	// Track count for current period
+	let periodTrackCount = $derived.by(() => {
+		if (currentPeriod === 0 || !periods.length) return tracks.length
+		const period = periods[currentPeriod - 1]
+		return tracks.filter((t) => {
+			const d = new Date(t.created_at)
+			return d >= period.startDate && d < period.endDate
+		}).length
+	})
+
 	// Reset period when time period changes
 	function onTimePeriodChange() {
 		currentPeriod = 0
@@ -270,7 +283,8 @@
 									{value}
 								</a>
 							</span>
-							<span class="count">{count}</span>
+							<span class="count">{count} / {periodTrackCount}</span>
+							<span class="bar" style="--pct: {((count / maxCount) * 100).toFixed(1)}%"></span>
 						</li>
 					{/each}
 				</ol>
@@ -332,5 +346,38 @@
 
 	.list {
 		margin: 0 0.5rem;
+	}
+
+	.list li {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.375rem 0.25rem;
+		border-bottom: 1px solid var(--gray-4);
+	}
+
+	.list li:first-child {
+		border-top: 1px solid var(--gray-4);
+	}
+
+	.list .tag {
+		flex: 0 0 auto;
+	}
+
+	.list .count {
+		flex: 0 0 auto;
+		font-variant-numeric: tabular-nums;
+		color: var(--gray-11);
+		font-size: 0.85em;
+		min-width: 2ch;
+		text-align: right;
+	}
+
+	.bar {
+		flex: 1;
+		height: 2px;
+		background: linear-gradient(to left, var(--accent-6) var(--pct), var(--gray-7) var(--pct));
+		border-radius: 1px;
+		align-self: center;
 	}
 </style>

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -7,6 +7,9 @@
 	import {getChannelTags} from '$lib/utils'
 	import InputRange from '$lib/components/input-range.svelte'
 	import TagChain from '$lib/components/tag-chain.svelte'
+	import PopoverMenu from '$lib/components/popover-menu.svelte'
+	import Icon from '$lib/components/icon.svelte'
+	import {tooltip} from '$lib/components/tooltip-attachment.svelte.js'
 	import * as m from '$lib/paraglide/messages'
 
 	let slug = $derived(page.params.slug)
@@ -21,6 +24,22 @@
 	let timePeriod = $state('year')
 	let currentPeriod = $state(0)
 	let display = $state('list')
+
+	const filterLabelMap = {
+		all: () => m.tags_filter_all(),
+		'single-use': () => m.tags_filter_single(),
+		frequent: () => m.tags_filter_frequent(),
+		rare: () => m.tags_filter_rare()
+	}
+
+	const periodLabelMap = {
+		year: () => m.tags_period_years(),
+		solstice: () => m.tags_period_solstices(),
+		month: () => m.tags_period_months()
+	}
+
+	const displayIconMap = {list: 'unordered-list', chain: 'share-alt'}
+	const displayLabelMap = {list: () => 'List', chain: () => 'Chain'}
 
 	// Date range from tracks
 	let dateRange = $derived.by(() => {
@@ -143,30 +162,68 @@
 {:else}
 	<main>
 		<header class="row">
-			<menu>
-				<label title={m.tags_filter_label()}>
-					<select bind:value={filter}>
-						<option value="all">{m.tags_filter_all()}</option>
-						<option value="single-use">{m.tags_filter_single()}</option>
-						<option value="frequent">{m.tags_filter_frequent()}</option>
-						<option value="rare">{m.tags_filter_rare()}</option>
-					</select>
-				</label>
-				<label title={m.tags_period_label()}>
-					<select bind:value={timePeriod} onchange={onTimePeriodChange}>
-						<option value="year">{m.tags_period_years()}</option>
-						<option value="solstice">{m.tags_period_solstices()}</option>
-						<option value="month">{m.tags_period_months()}</option>
-					</select>
-				</label>
-				<div class="display-toggle">
-					<button class:active={display === 'list'} onclick={() => (display = 'list')} title="List"> ☰ </button>
-					<button class:active={display === 'chain'} onclick={() => (display = 'chain')} title="Chain"> ⚡ </button>
-				</div>
-			</menu>
-			<!--
-			<h1>{m.tags_heading({name: channel.name})}</h1>
-			-->
+			<PopoverMenu id="tags-filter" closeOnClick={false}>
+				{#snippet trigger()}<Icon icon="filter" /><span>{filterLabelMap[filter]()}</span>{/snippet}
+				<menu>
+					<button class:active={filter === 'all'} onclick={() => (filter = 'all')}>
+						{filterLabelMap.all()}
+					</button>
+					<button class:active={filter === 'single-use'} onclick={() => (filter = 'single-use')}>
+						{filterLabelMap['single-use']()}
+					</button>
+					<button class:active={filter === 'frequent'} onclick={() => (filter = 'frequent')}>
+						{filterLabelMap.frequent()}
+					</button>
+					<button class:active={filter === 'rare'} onclick={() => (filter = 'rare')}>
+						{filterLabelMap.rare()}
+					</button>
+				</menu>
+			</PopoverMenu>
+
+			<PopoverMenu id="tags-period" closeOnClick={false}>
+				{#snippet trigger()}<Icon icon="calendar" /><span>{periodLabelMap[timePeriod]()}</span>{/snippet}
+				<menu>
+					<button
+						class:active={timePeriod === 'year'}
+						onclick={() => {
+							timePeriod = 'year'
+							currentPeriod = 0
+						}}
+					>
+						{periodLabelMap.year()}
+					</button>
+					<button
+						class:active={timePeriod === 'solstice'}
+						onclick={() => {
+							timePeriod = 'solstice'
+							currentPeriod = 0
+						}}
+					>
+						{periodLabelMap.solstice()}
+					</button>
+					<button
+						class:active={timePeriod === 'month'}
+						onclick={() => {
+							timePeriod = 'month'
+							currentPeriod = 0
+						}}
+					>
+						{periodLabelMap.month()}
+					</button>
+				</menu>
+			</PopoverMenu>
+
+			<PopoverMenu id="tags-display" closeOnClick={false} style="margin-left: auto;">
+				{#snippet trigger()}<Icon icon={displayIconMap[display]} />{displayLabelMap[display]()}{/snippet}
+				<menu>
+					<button class:active={display === 'list'} onclick={() => (display = 'list')}>
+						<Icon icon="unordered-list" /><small>List</small>
+					</button>
+					<button class:active={display === 'chain'} onclick={() => (display = 'chain')}>
+						<Icon icon="share-alt" /><small>Chain</small>
+					</button>
+				</menu>
+			</PopoverMenu>
 		</header>
 
 		{#if periods.length > 0}
@@ -227,32 +284,9 @@
 <style>
 	header {
 		margin: 0.5rem 0.5rem 0;
-		place-items: center;
-	}
-
-	.display-toggle {
 		display: flex;
-		gap: 0.25rem;
-		margin-left: auto;
-	}
-
-	.display-toggle button {
-		padding: 0.375rem 0.5rem;
-		background: var(--gray-3);
-		border: 1px solid var(--gray-7);
-		border-radius: var(--border-radius);
-		cursor: pointer;
-		font-size: 1rem;
-	}
-
-	.display-toggle button:hover {
-		background: var(--gray-4);
-	}
-
-	.display-toggle button.active {
-		background: var(--accent-9);
-		color: var(--gray-1);
-		border-color: var(--accent-9);
+		gap: 0.5rem;
+		flex-wrap: wrap;
 	}
 
 	.scrubber {

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -74,7 +74,7 @@
 		alpha: () => 'A–Z'
 	}
 
-	const displayIconMap = {list: 'unordered-list', cloud: 'tag', chain: 'link'}
+	const displayIconMap = {list: 'unordered-list', cloud: 'tag', chain: 'code-branch'}
 	const displayLabelMap = {list: () => 'List', cloud: () => 'Cloud', chain: () => 'Chain'}
 
 	// Date range from tracks
@@ -267,7 +267,7 @@
 						<Icon icon="tag" /><small>Cloud</small>
 					</button>
 					<button class:active={display === 'chain'} onclick={() => (display = 'chain')}>
-						<Icon icon="link" /><small>Chain</small>
+						<Icon icon="code-branch" /><small>Chain</small>
 					</button>
 				</menu>
 			</PopoverMenu>

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -216,7 +216,7 @@
 		const basePath = resolve('/[slug]/tags', {slug})
 		const nextPath = `${basePath}${queryString}`
 		const currentPath = `${page.url.pathname}${page.url.search}`
-		if (currentPath !== nextPath) replaceState(`${resolve('/[slug]/tags', {slug})}${queryString}`, {})
+		if (currentPath !== nextPath) replaceState(resolve('/[slug]/tags', {slug}) + queryString, {})
 	})
 </script>
 
@@ -332,7 +332,13 @@
 			<p style="margin: 1rem;">{m.channel_loading_tracks()}</p>
 		{:else if visibleTags.length > 0}
 			{#if display === 'chain'}
-				<TagChain tags={visibleTags} tracks={periodTracks} channelSlug={channel.slug} bind:chainTags />
+				<TagChain
+					tags={visibleTags}
+					tracks={periodTracks}
+					totalCount={periodTrackCount}
+					channelSlug={channel.slug}
+					bind:chainTags
+				/>
 			{:else if display === 'cloud'}
 				<div class="cloud">
 					{#each visibleTags as { value, count } (value)}
@@ -341,7 +347,7 @@
 								? ((count / maxVisibleTagCount) * 0.9).toFixed(2)
 								: '0.0'}rem)"
 						>
-							<a href={resolve(`/search?q=@${channel.slug} ${value}`)}>
+							<a href={resolve('/[slug]/tracks', {slug}) + `?tags=${encodeURIComponent(value)}`}>
 								{value}
 							</a>
 						</span>
@@ -352,7 +358,7 @@
 					{#each visibleTags as { value, count } (value)}
 						<li>
 							<span class="tag">
-								<a href={resolve(`/search?q=@${channel.slug} ${value}`)}>
+								<a href={resolve('/[slug]/tracks', {slug}) + `?tags=${encodeURIComponent(value)}`}>
 									{value}
 								</a>
 							</span>

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+	import {replaceState} from '$app/navigation'
 	import {resolve} from '$app/paths'
 	import {getTracksQueryCtx} from '$lib/contexts'
 	import {Tween} from 'svelte/motion'
@@ -12,7 +13,7 @@
 	import Icon from '$lib/components/icon.svelte'
 	import * as m from '$lib/paraglide/messages'
 
-	let slug = $derived(page.params.slug)
+	let slug = $derived(page.params.slug ?? '')
 
 	// Get tracks from layout (query stays alive during navigation)
 	const tracksQuery = getTracksQueryCtx()
@@ -20,11 +21,36 @@
 	let channel = $derived([...channelsCollection.state.values()].find((c) => c.slug === slug))
 	let tracks = $derived(tracksQuery.data || [])
 
-	let filter = $state('all')
-	let timePeriod = $state('year')
-	let currentPeriod = $state(0)
-	let display = $state('list')
-	let sort = $state('count')
+	const filterValues = ['all', 'single-use', 'frequent', 'rare']
+	const periodValues = ['year', 'solstice', 'month']
+	const displayValues = ['list', 'chain']
+	const sortValues = ['count', 'alpha']
+
+	const readEnumParam = (key, validValues, fallback) => {
+		const value = page.url.searchParams.get(key)
+		return validValues.includes(value) ? value : fallback
+	}
+
+	const readPeriodParam = () => {
+		const value = Number(page.url.searchParams.get('period') ?? 0)
+		return Number.isInteger(value) && value >= 0 ? value : 0
+	}
+
+	const readTagsParam = () => {
+		const value = page.url.searchParams.get('tags')
+		if (!value) return []
+		return value
+			.split(',')
+			.map((v) => v.trim())
+			.filter(Boolean)
+	}
+
+	let filter = $state(readEnumParam('filter', filterValues, 'all'))
+	let timePeriod = $state(readEnumParam('timePeriod', periodValues, 'year'))
+	let currentPeriod = $state(readPeriodParam())
+	let display = $state(readEnumParam('display', displayValues, 'list'))
+	let sort = $state(readEnumParam('sort', sortValues, 'count'))
+	let chainTags = $state(readTagsParam())
 
 	const filterLabelMap = {
 		all: () => m.tags_filter_all(),
@@ -122,6 +148,7 @@
 	let periodTracks = $derived.by(() => {
 		if (currentPeriod === 0 || !periods.length) return tracks
 		const period = periods[currentPeriod - 1]
+		if (!period) return tracks
 		return tracks.filter((track) => {
 			const date = new Date(track.created_at)
 			return date >= period.startDate && date < period.endDate
@@ -157,6 +184,26 @@
 	const tagCount = new Tween(0, {duration: 400, easing: cubicOut})
 	$effect(() => {
 		tagCount.set(filteredTags.length)
+	})
+
+	$effect(() => {
+		if (currentPeriod <= periods.length) return
+		currentPeriod = periods.length
+	})
+
+	$effect(() => {
+		const parts = []
+		if (display !== 'list') parts.push(`display=${encodeURIComponent(display)}`)
+		if (sort !== 'count') parts.push(`sort=${encodeURIComponent(sort)}`)
+		if (filter !== 'all') parts.push(`filter=${encodeURIComponent(filter)}`)
+		if (timePeriod !== 'year') parts.push(`timePeriod=${encodeURIComponent(timePeriod)}`)
+		if (currentPeriod !== 0) parts.push(`period=${currentPeriod}`)
+		if (chainTags.length) parts.push(`tags=${chainTags.map(encodeURIComponent).join(',')}`)
+		const search = parts.length ? `?${parts.join('&')}` : ''
+		const basePath = resolve('/[slug]/tags', {slug})
+		const nextPath = `${basePath}${search}`
+		const currentPath = `${page.url.pathname}${page.url.search}`
+		if (currentPath !== nextPath) replaceState(`${resolve('/[slug]/tags', {slug})}${search}`, {})
 	})
 </script>
 
@@ -275,7 +322,7 @@
 			<p style="margin: 1rem;">{m.channel_loading_tracks()}</p>
 		{:else if filteredTags.length > 0}
 			{#if display === 'chain'}
-				<TagChain tags={filteredTags} tracks={periodTracks} channelSlug={channel.slug} />
+				<TagChain tags={filteredTags} tracks={periodTracks} channelSlug={channel.slug} bind:chainTags />
 			{:else}
 				<ol class="list">
 					{#each filteredTags as { value, count } (value)}

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -11,6 +11,7 @@
 	import TagChain from '$lib/components/tag-chain.svelte'
 	import PopoverMenu from '$lib/components/popover-menu.svelte'
 	import Icon from '$lib/components/icon.svelte'
+	import SearchInput from '$lib/components/search-input.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let slug = $derived(page.params.slug ?? '')
@@ -23,7 +24,7 @@
 
 	const filterValues = ['all', 'single-use', 'frequent', 'rare']
 	const periodValues = ['year', 'solstice', 'month']
-	const displayValues = ['list', 'chain']
+	const displayValues = ['list', 'cloud', 'chain']
 	const sortValues = ['count', 'alpha']
 
 	const readEnumParam = (key, validValues, fallback) => {
@@ -45,12 +46,15 @@
 			.filter(Boolean)
 	}
 
+	const readSearchParam = () => page.url.searchParams.get('search') ?? ''
+
 	let filter = $state(readEnumParam('filter', filterValues, 'all'))
 	let timePeriod = $state(readEnumParam('timePeriod', periodValues, 'year'))
 	let currentPeriod = $state(readPeriodParam())
 	let display = $state(readEnumParam('display', displayValues, 'list'))
 	let sort = $state(readEnumParam('sort', sortValues, 'count'))
 	let chainTags = $state(readTagsParam())
+	let search = $state(readSearchParam())
 
 	const filterLabelMap = {
 		all: () => m.tags_filter_all(),
@@ -70,8 +74,8 @@
 		alpha: () => 'A–Z'
 	}
 
-	const displayIconMap = {list: 'unordered-list', chain: 'share-alt'}
-	const displayLabelMap = {list: () => 'List', chain: () => 'Chain'}
+	const displayIconMap = {list: 'unordered-list', cloud: 'tag', chain: 'share-alt'}
+	const displayLabelMap = {list: () => 'List', cloud: () => 'Cloud', chain: () => 'Chain'}
 
 	// Date range from tracks
 	let dateRange = $derived.by(() => {
@@ -173,6 +177,14 @@
 		return tags // count is already sorted from getChannelTags
 	})
 
+	let visibleTags = $derived.by(() => {
+		const query = search.trim().toLowerCase()
+		if (!query) return filteredTags
+		return filteredTags.filter((tag) => tag.value.includes(query))
+	})
+
+	let maxVisibleTagCount = $derived(visibleTags.reduce((max, tag) => Math.max(max, tag.count), 1))
+
 	// Track count for current period
 	let periodTrackCount = $derived(periodTracks.length)
 
@@ -183,7 +195,7 @@
 	// Animated tag count
 	const tagCount = new Tween(0, {duration: 400, easing: cubicOut})
 	$effect(() => {
-		tagCount.set(filteredTags.length)
+		tagCount.set(visibleTags.length)
 	})
 
 	$effect(() => {
@@ -198,12 +210,13 @@
 		if (filter !== 'all') parts.push(`filter=${encodeURIComponent(filter)}`)
 		if (timePeriod !== 'year') parts.push(`timePeriod=${encodeURIComponent(timePeriod)}`)
 		if (currentPeriod !== 0) parts.push(`period=${currentPeriod}`)
+		if (search.trim()) parts.push(`search=${encodeURIComponent(search.trim())}`)
 		if (chainTags.length) parts.push(`tags=${chainTags.map(encodeURIComponent).join(',')}`)
-		const search = parts.length ? `?${parts.join('&')}` : ''
+		const queryString = parts.length ? `?${parts.join('&')}` : ''
 		const basePath = resolve('/[slug]/tags', {slug})
-		const nextPath = `${basePath}${search}`
+		const nextPath = `${basePath}${queryString}`
 		const currentPath = `${page.url.pathname}${page.url.search}`
-		if (currentPath !== nextPath) replaceState(`${resolve('/[slug]/tags', {slug})}${search}`, {})
+		if (currentPath !== nextPath) replaceState(`${resolve('/[slug]/tags', {slug})}${queryString}`, {})
 	})
 </script>
 
@@ -211,10 +224,12 @@
 	<p style="padding: 1rem;">{m.channel_not_found()}</p>
 {:else}
 	<main>
-		<header class="row">
-			<PopoverMenu id="tags-filter" closeOnClick={false}>
-				{#snippet trigger()}<Icon icon="filter" /><span>{filterLabelMap[filter]()}</span>{/snippet}
-				<menu>
+		<menu class="filtermenu">
+			<SearchInput bind:value={search} placeholder={m.tracks_filter_placeholder()} />
+
+			<PopoverMenu id="tags-data" closeOnClick={false}>
+				{#snippet trigger()}<Icon icon="filter" /><span>Data</span>{/snippet}
+				<menu class="nav-vertical">
 					<button class:active={filter === 'all'} onclick={() => (filter = 'all')}>
 						{filterLabelMap.all()}
 					</button>
@@ -228,11 +243,7 @@
 						{filterLabelMap.rare()}
 					</button>
 				</menu>
-			</PopoverMenu>
-
-			<PopoverMenu id="tags-period" closeOnClick={false}>
-				{#snippet trigger()}<Icon icon="calendar" /><span>{periodLabelMap[timePeriod]()}</span>{/snippet}
-				<menu>
+				<menu class="nav-vertical">
 					<button
 						class:active={timePeriod === 'year'}
 						onclick={() => {
@@ -261,11 +272,7 @@
 						{periodLabelMap.month()}
 					</button>
 				</menu>
-			</PopoverMenu>
-
-			<PopoverMenu id="tags-sort" closeOnClick={false}>
-				{#snippet trigger()}<Icon icon="sort-asc" /><span>{sortLabelMap[sort]()}</span>{/snippet}
-				<menu>
+				<menu class="nav-vertical">
 					<button class:active={sort === 'count'} onclick={() => (sort = 'count')}>
 						{sortLabelMap.count()}
 					</button>
@@ -277,16 +284,19 @@
 
 			<PopoverMenu id="tags-display" closeOnClick={false} style="margin-left: auto;">
 				{#snippet trigger()}<Icon icon={displayIconMap[display]} />{displayLabelMap[display]()}{/snippet}
-				<menu>
+				<menu class="view-modes">
 					<button class:active={display === 'list'} onclick={() => (display = 'list')}>
 						<Icon icon="unordered-list" /><small>List</small>
+					</button>
+					<button class:active={display === 'cloud'} onclick={() => (display = 'cloud')}>
+						<Icon icon="tag" /><small>Cloud</small>
 					</button>
 					<button class:active={display === 'chain'} onclick={() => (display = 'chain')}>
 						<Icon icon="share-alt" /><small>Chain</small>
 					</button>
 				</menu>
 			</PopoverMenu>
-		</header>
+		</menu>
 
 		{#if periods.length > 0}
 			<div class="scrubber">
@@ -320,12 +330,26 @@
 
 		{#if tracksQuery.isLoading}
 			<p style="margin: 1rem;">{m.channel_loading_tracks()}</p>
-		{:else if filteredTags.length > 0}
+		{:else if visibleTags.length > 0}
 			{#if display === 'chain'}
-				<TagChain tags={filteredTags} tracks={periodTracks} channelSlug={channel.slug} bind:chainTags />
+				<TagChain tags={visibleTags} tracks={periodTracks} channelSlug={channel.slug} bind:chainTags />
+			{:else if display === 'cloud'}
+				<div class="cloud">
+					{#each visibleTags as { value, count } (value)}
+						<span
+							style="font-size: calc(0.8rem + {maxVisibleTagCount
+								? ((count / maxVisibleTagCount) * 0.9).toFixed(2)
+								: '0.0'}rem)"
+						>
+							<a href={resolve(`/search?q=@${channel.slug} ${value}`)}>
+								{value}
+							</a>
+						</span>
+					{/each}
+				</div>
 			{:else}
 				<ol class="list">
-					{#each filteredTags as { value, count } (value)}
+					{#each visibleTags as { value, count } (value)}
 						<li>
 							<span class="tag">
 								<a href={resolve(`/search?q=@${channel.slug} ${value}`)}>
@@ -348,11 +372,23 @@
 {/if}
 
 <style>
-	header {
+	.filtermenu {
 		margin: 0.5rem 0.5rem 0;
 		display: flex;
+		align-items: center;
 		gap: 0.5rem;
-		flex-wrap: wrap;
+		position: sticky;
+		top: 0.5rem;
+		z-index: 1;
+	}
+
+	.filtermenu :global(.search-input) {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.filtermenu :global(.search-input input) {
+		width: 100%;
 	}
 
 	.scrubber {
@@ -431,5 +467,21 @@
 		background: linear-gradient(to left, var(--accent-6) var(--pct), var(--gray-7) var(--pct));
 		border-radius: 1px;
 		align-self: center;
+	}
+
+	.cloud {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem 0.625rem;
+		margin: 0.5rem;
+		line-height: 1.35;
+	}
+
+	.cloud a {
+		text-decoration: none;
+	}
+
+	.cloud a:hover {
+		text-decoration: underline;
 	}
 </style>

--- a/src/routes/[slug]/tags/+page.svelte
+++ b/src/routes/[slug]/tags/+page.svelte
@@ -243,6 +243,10 @@
 						{filterLabelMap.rare()}
 					</button>
 				</menu>
+			</PopoverMenu>
+
+			<PopoverMenu id="tags-order" closeOnClick={false}>
+				{#snippet trigger()}<Icon icon="sort" />{sortLabelMap[sort]()}{/snippet}
 				<menu class="nav-vertical">
 					<button class:active={sort === 'count'} onclick={() => (sort = 'count')}>
 						{sortLabelMap.count()}


### PR DESCRIPTION
## Summary

A mobile-first, plain HTML alternative to the 3D galaxy view.

- Tag chain selection (AND logic)
- Sticky bar showing selected tags with actions
- Play matching tracks button
- View tracks link
- Plain ordered list of tags as links

## Changes

- New `TagChain.svelte` component
- Updated `tags/+page.svelte` with display toggle (List ↔ Chain)
- Simple, accessible HTML/CSS - no WebGL, no SVG, no d3-force

## Usage

1. Go to any channel's Tags page (e.g., `/radio4000/tags`)
2. Click the ⚡ button in the header to switch to Chain view
3. Click tags to add them to your chain
4. Use Play or View tracks actions