### PR TITLE
Channel deck UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## June 2026
 
+- #Deck Track progress bar with scrub and remaining time is on by default
 - #Home Featured tracks rotate daily and include more channels
 - #Explore Explore defaults to channels with more than 10 tracks
 - #Map Channel map gets high-contrast markers, instant tile switching, and an auto-opening pin

--- a/docs/auto-radio.md
+++ b/docs/auto-radio.md
@@ -46,20 +46,9 @@ Drift is computed continuously in `player.svelte` while playing:
 - Broadcast drift: compare current playback to `calculateSeekTime(...)` from `broadcast.js`.
 - Both use a `2s` tolerance.
 
-Range seek and other UI controls do not directly set `auto_radio_drifted` anymore.
+Drift is detected only by this comparison — range seek and other UI controls do not set `auto_radio_drifted` directly.
 
-The Auto button uses the same `infinite` icon in both states:
-
-- synced: ghost button style + animated rotating gradient stroke (live/synced signal)
-- drifted: normal button style
-
-All infinity auto controls now use one shared UI component: `components/auto-radio-button.svelte`.
-
-Accessibility: with `prefers-reduced-motion: reduce`, the synced icon falls back to a static accent stroke (no animation).
-
-In deck player UI, Auto mode appears as a full-width action row below the channel header and above the video. It combines icon, status text, presence count, and resync action in one button.
-
-`resyncAutoRadio` now re-applies the stored view (`processViewTracks`) before recomputing the deterministic shuffle, so filtered/tag/search auto-radio resyncs correctly.
+`resyncAutoRadio` applies the stored view (`processViewTracks`) before recomputing the deterministic shuffle, so filtered/tag/search auto-radio resyncs correctly.
 
 ## Deck state
 
@@ -78,7 +67,7 @@ Auto-radio uses these `Deck` fields:
 - `player/auto-radio.test.ts` — determinism, viewSeed, epochFromTracks, hashString tests
 - `api.ts` — `joinAutoRadio`, `resyncAutoRadio`
 - `components/auto-radio-button.svelte` — shared infinity auto button UI across headers/pages/search
-- `components/player.svelte` — computed drift detection + auto/live status UI
+- `components/player.svelte` — computed drift detection
 - `broadcast.js` — `calculateSeekTime` (speed-aware expected position for listeners)
 - `[slug]/+layout.svelte` — full-channel join button
 - `[slug]/+page.svelte` — per-tag join buttons

--- a/docs/browser-testing.md
+++ b/docs/browser-testing.md
@@ -57,8 +57,46 @@ agent-browser eval "JSON.stringify(window.r5.appState)"
 | `window.r5.sdk`                            | Supabase SDK instance                          |
 | `window.r5.channelsCollection._state.size` | channels loaded                                |
 | `window.r5.tracksCollection._state.size`   | tracks loaded                                  |
+| `window.r5.api`                            | every `api.ts` function — drive logic directly |
+| `window.r5.decks()`                        | deck probe — see "Player & decks" below        |
 
 Wrap objects in `JSON.stringify()`.
+
+`window.r5.api` lets you trigger app logic without clicking — e.g.
+`eval "window.r5.api.toggleChannelPlay({id, slug:'oskar'})"`. Faster and less
+flaky than driving the player through the UI.
+
+### Player & decks
+
+The player runs N decks (`appState.decks`, keyed by id) with one `active_deck_id`.
+Multiple decks can play at once — there is no exclusive-playback rule.
+
+**Assert on resolution, not playback.** Muted/backgrounded YouTube (and SoundCloud)
+iframes **self-pause in headless Chromium**, especially across navigations — so
+`is_playing` reads flaky and is _not_ reliable ground truth. What _is_
+deterministic: which deck is `active_deck_id` and what slug each deck holds. Test
+those. "Tap play on channel X resolves to and focuses the deck holding X" is a
+resolution fact the headless audio state can't break.
+
+Probe decks in one call:
+
+```
+agent-browser eval "JSON.stringify(window.r5.decks())"
+# → [{id, slug, playing, active, auto}, ...]
+```
+
+**Two-deck setup** (the arrangement that catches display-vs-action bugs — a deck
+acting on a channel other than the active one):
+
+```
+agent-browser eval "window.r5.api.playChannelInNewDeck({id:'<id-a>', slug:'channel-a'})"
+agent-browser eval "window.r5.api.playChannelInNewDeck({id:'<id-b>', slug:'channel-b'})"
+# channel-b's deck is now active; channel-a's deck is loaded but not active.
+# Tapping channel-a's play control should resolve to channel-a's deck — assert
+# active flips to it via window.r5.decks(), not that audio resumed.
+```
+
+Keep decks muted while testing: `eval "Object.values(window.r5.appState.decks).forEach(d => d.muted = true)"`.
 
 ### UI patterns
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -32,7 +32,7 @@ import {
 	epochFromTracks,
 	type AutoTrack
 } from '$lib/player/auto-radio'
-import {findAutoDecksForChannel, pickAutoResyncDeck} from '$lib/deck'
+import {findAutoDecksForChannel, findChannelDeck, pickAutoResyncDeck} from '$lib/deck'
 import {processViewTracks} from '$lib/views.svelte'
 import {serializeView, viewLabel, normalizeView, type View} from '$lib/views'
 
@@ -327,11 +327,7 @@ export async function playChannel(
 	await playTrack(deckId, trackId ?? ids[0], null, 'play_channel')
 }
 
-/**
- * @param {string} trackId
- * @param {string} [slug]
- */
-export async function playTrackInNewDeck(trackId, slug) {
+export async function playTrackInNewDeck(trackId: string, slug?: string) {
 	const deck = addDeck()
 	deck.compact = true
 	appState.active_deck_id = deck.id
@@ -341,22 +337,14 @@ export async function playTrackInNewDeck(trackId, slug) {
 	await playTrack(deck.id, trackId, null, 'user_click_track')
 }
 
-/**
- * @param {{id: string, slug: string}} channel
- * @param {string} [trackId]
- */
-export async function playChannelInNewDeck(channel, trackId) {
+export async function playChannelInNewDeck(channel: {id: string; slug: string}, trackId?: string) {
 	const deck = addDeck()
 	appState.active_deck_id = deck.id
 	await playChannel(deck.id, channel, trackId)
 }
 
-/**
- * Play channel starting from random track with shuffle enabled
- * @param {number} deckId
- * @param {{id: string, slug: string}} channel
- */
-export async function shufflePlayChannel(deckId, {id, slug}) {
+/** Play channel starting from random track with shuffle enabled */
+export async function shufflePlayChannel(deckId: number, {id, slug}: {id: string; slug: string}) {
 	log.log('shuffle_play_channel', {deckId, id, slug})
 	leaveBroadcast(deckId)
 	const d = getDeck(deckId)
@@ -421,11 +409,7 @@ export function loadDeckView(
 	deck.view = normalizeView(view)
 }
 
-/**
- * @param {number} deckId
- * @param {string[]} trackIds
- */
-export function addToPlaylist(deckId, trackIds) {
+export function addToPlaylist(deckId: number, trackIds: string[]) {
 	const deck = getDeck(deckId)
 	if (!deck) {
 		log.warn('addToPlaylist: no deck', {deckId})
@@ -449,12 +433,8 @@ export function addToPlaylist(deckId, trackIds) {
 	})
 }
 
-/**
- * Queue track(s) to play after the current track
- * @param {number} deckId
- * @param {string | string[]} trackIds
- */
-export function playNext(deckId, trackIds) {
+/** Queue track(s) to play after the current track */
+export function playNext(deckId: number, trackIds: string | string[]) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	const ids = Array.isArray(trackIds) ? trackIds : [trackIds]
@@ -480,12 +460,8 @@ export function playNext(deckId, trackIds) {
 	log.log('play_next', {deckId, ids, after: currentId})
 }
 
-/**
- * Remove track from queue
- * @param {number} deckId
- * @param {string} trackId
- */
-export function removeFromQueue(deckId, trackId) {
+/** Remove track from queue */
+export function removeFromQueue(deckId: number, trackId: string) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	deck.playlist_tracks = queueRemove(deck.playlist_tracks, trackId)
@@ -510,16 +486,14 @@ export function toggleTheme() {
 	setTheme(cycle[(cycle.indexOf(appState.theme) + 1) % cycle.length])
 }
 
-/** @param {number} deckId */
-export function toggleQueuePanel(deckId) {
+export function toggleQueuePanel(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	deck.hide_queue_panel = !deck.hide_queue_panel
 	maybeBroadcastNotify()
 }
 
-/** @param {number} deckId */
-export function toggleVideo(deckId) {
+export function toggleVideo(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	const newValue = !deck.hide_video_player
@@ -533,8 +507,7 @@ export function toggleVideo(deckId) {
 	maybeBroadcastNotify()
 }
 
-/** @param {number} deckId */
-export function toggleDeckCompact(deckId) {
+export function toggleDeckCompact(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	const newValue = !deck.compact
@@ -551,8 +524,7 @@ export function toggleDeckCompact(deckId) {
 	}
 }
 
-/** @param {number} deckId */
-export function togglePlayerExpanded(deckId) {
+export function togglePlayerExpanded(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	const newValue = !deck.expanded
@@ -571,8 +543,7 @@ export function togglePlayerExpanded(deckId) {
 	}
 }
 
-/** @param {KeyboardEvent} [event] */
-export function openSearch(event) {
+export function openSearch(event?: KeyboardEvent) {
 	event?.preventDefault()
 	const hasVisibleDeck = Object.values(appState.decks).some((d) => !d.compact)
 	if (hasVisibleDeck) {
@@ -585,8 +556,7 @@ export function openSearch(event) {
 	goto('/search')
 }
 
-/** @param {number} deckId */
-export async function togglePlayPause(deckId) {
+export async function togglePlayPause(deckId: number) {
 	const deck = getDeck(deckId)
 	let player = getMediaPlayer(deckId)
 	if (!player) {
@@ -613,12 +583,8 @@ export async function togglePlayPause(deckId) {
 	maybeBroadcastNotify()
 }
 
-/**
- * Play from this track to end of list
- * @param {number} deckId
- * @param {string} trackId
- */
-export function playFromHere(deckId, trackId) {
+/** Play from this track to end of list */
+export function playFromHere(deckId: number, trackId: string) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	const idx = deck.playlist_tracks.indexOf(trackId)
@@ -631,11 +597,8 @@ export function playFromHere(deckId, trackId) {
 	log.log('play_from_here', {deckId, trackId, remaining: fromHere.length})
 }
 
-/**
- * Clear the queue but keep current track
- * @param {number} deckId
- */
-export function clearQueue(deckId) {
+/** Clear the queue but keep current track */
+export function clearQueue(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	const current = deck.playlist_track
@@ -677,11 +640,8 @@ export function applyRemoteState(deckId: number, state: Partial<Deck>) {
 	Object.assign(deck, state)
 }
 
-/**
- * Toggle shuffle mode on/off
- * @param {number} deckId
- */
-export function toggleShuffle(deckId) {
+/** Toggle shuffle mode on/off */
+export function toggleShuffle(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	deck.shuffle = !deck.shuffle
@@ -693,11 +653,8 @@ export function toggleShuffle(deckId) {
 	}
 }
 
-/**
- * Shuffle remaining tracks in place
- * @param {number} deckId
- */
-export function shuffleRemaining(deckId) {
+/** Shuffle remaining tracks in place */
+export function shuffleRemaining(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	const current = deck.playlist_track
@@ -707,11 +664,8 @@ export function shuffleRemaining(deckId) {
 	log.log('shuffle_remaining', {deckId, current})
 }
 
-/**
- * Rotate queue: move played tracks to end
- * @param {number} deckId
- */
-export function rotateQueue(deckId) {
+/** Rotate queue: move played tracks to end */
+export function rotateQueue(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	const current = deck.playlist_track
@@ -780,11 +734,7 @@ export function togglePlay(player: MediaPlayer) {
 	}
 }
 
-/**
- * @param {number} deckId
- * @param {number} seconds
- */
-export function seekTo(deckId, seconds) {
+export function seekTo(deckId: number, seconds: number) {
 	const mediaEl = getMediaPlayer(deckId)
 	if (!mediaEl) {
 		log.warn('seekTo: no media element found')
@@ -841,8 +791,7 @@ export function previous(deckId: number, endReason: PlayEndReason) {
 	}
 }
 
-/** @param {number} deckId */
-export function eject(deckId) {
+export function eject(deckId: number) {
 	const deck = getDeck(deckId)
 	if (!deck) return
 	clearAllQueue(deckId)
@@ -983,6 +932,50 @@ export async function resyncAutoRadio(deckId: number) {
 	} else {
 		await seekToAutoRadioOffset(deckId, shuffled, totalDuration, rotationStartUnix)
 	}
+}
+
+/**
+ * Default "tap play" for a channel. Starts live auto-radio when the channel has
+ * enough duration data, otherwise falls back to latest-first playback.
+ * Always targets the active deck — auto-radio is keyed by the active deck
+ * (see {@link toggleChannelAutoRadio}), so there is no deck to thread through.
+ */
+export async function playChannelAuto(channel: {id: string; slug: string}) {
+	const tracks = await loadChannelTracks(channel.slug)
+	if (hasAutoRadioCoverage(tracks)) {
+		await toggleChannelAutoRadio(channel.slug, tracks)
+	} else {
+		await playChannel(appState.active_deck_id, channel)
+	}
+}
+
+/**
+ * Primary "tap play" for a channel — keyed by the channel, not a deck. Resolves the
+ * deck holding the channel via {@link findChannelDeck} (the same helper surfaces use
+ * for display), so the deck shown and the deck acted on are always the same one.
+ * If a deck already holds this channel: focus it, then resync a drifted auto-radio
+ * else pause/resume. Otherwise start fresh on the active deck from `trackId`, or
+ * smartly via {@link playChannelAuto} (auto-radio if the channel has coverage, else
+ * latest-first).
+ */
+export async function toggleChannelPlay(channel: {id: string; slug: string}, trackId?: string) {
+	const deck = findChannelDeck(appState.decks, appState.active_deck_id, channel.slug)
+	if (deck) {
+		// Focus the resolved deck so global controls (spacebar, player surface) follow
+		// the deck the user just acted on — avoids a second silent stream of the channel.
+		appState.active_deck_id = deck.id
+		// Already this channel: resync a drifted auto-radio, else pause/resume.
+		if (deck.auto_radio && deck.auto_radio_drifted) await resyncAutoRadio(deck.id)
+		else togglePlayPause(deck.id)
+		return
+	}
+	// Fresh start on the active deck. leaveBroadcast is required for the auto path —
+	// joinAutoRadio never leaves a broadcast. The playChannel path leaves it again
+	// internally; the double-call is harmless.
+	const deckId = appState.active_deck_id
+	leaveBroadcast(deckId)
+	if (trackId) await playChannel(deckId, channel, trackId)
+	else await playChannelAuto(channel)
 }
 
 export async function toggleChannelAutoRadio(slug: string, tracks?: Track[]) {

--- a/src/lib/app-state.svelte.ts
+++ b/src/lib/app-state.svelte.ts
@@ -125,7 +125,7 @@ export const defaultAppState: AppState = {
 	default_new_deck_volume: 1,
 	autoplay_new_deck: true,
 	show_speed_control: false,
-	show_track_range_control: false,
+	show_track_range_control: true,
 	use_pointer_cursor: false,
 	font_family: undefined,
 

--- a/src/lib/components/auto-radio-button.svelte
+++ b/src/lib/components/auto-radio-button.svelte
@@ -1,28 +1,65 @@
 <script lang="ts">
 	import Icon from '$lib/components/icon.svelte'
+	import * as m from '$lib/paraglide/messages'
 
 	let {
-		synced = false,
-		title = 'Auto radio',
+		live = false,
+		drifted = false,
+		count = 0,
+		title,
 		ariaLabel,
 		size = 16,
-		className = '',
+		class: className = '',
 		...rest
 	}: {
-		synced?: boolean
+		live?: boolean
+		drifted?: boolean
+		count?: number
 		title?: string
 		ariaLabel?: string
 		size?: number
-		className?: string
+		class?: string
 		[key: string]: unknown
 	} = $props()
 
-	const resolvedAriaLabel = $derived(ariaLabel ?? title)
-	const classNames = $derived(
-		['auto-live-btn', className, synced ? 'ghost' : ''].filter(Boolean).join(' ')
-	)
+	// Active = engaged and in sync. Drifted reads as a resync call-to-action, so it drops active.
+	const resolvedTitle = $derived(title ?? (drifted ? m.auto_radio_resync() : m.auto_radio_join()))
+	const resolvedAriaLabel = $derived(ariaLabel ?? resolvedTitle)
+	// Only surface the badge when others are present (count includes you).
+	const showCount = $derived(count > 1)
 </script>
 
-<button type="button" class={classNames} {title} aria-label={resolvedAriaLabel} {...rest}>
+<button
+	type="button"
+	class={['auto-live-btn', {active: live && !drifted}, className]}
+	title={resolvedTitle}
+	aria-label={resolvedAriaLabel}
+	{...rest}
+>
 	<Icon icon="infinite" {size} />
+	{#if showCount}
+		<span class="count-badge" title="{count} listener{count === 1 ? '' : 's'}">{count}</span>
+	{/if}
 </button>
+
+<style>
+	.count-badge {
+		position: absolute;
+		top: calc(-1 * var(--space-1));
+		right: calc(-1 * var(--space-1));
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 1.1em;
+		height: 1.1em;
+		padding: 0 var(--space-1);
+		font-size: var(--font-1);
+		font-weight: 600;
+		line-height: 1;
+		color: var(--gray-1);
+		background: var(--gray-12);
+		border-radius: 1em;
+		box-shadow: 0 0 0 1.5px var(--color-interface, var(--gray-1));
+		pointer-events: none;
+	}
+</style>

--- a/src/lib/components/channel-canvas-bg.svelte
+++ b/src/lib/components/channel-canvas-bg.svelte
@@ -337,7 +337,8 @@
 		position: absolute;
 		inset: 0;
 		mix-blend-mode: overlay;
-		opacity: 0.3;
+		opacity: 0.12;
+		filter: blur(1px);
 		background-size: 160px 160px;
 		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 		mask-image: radial-gradient(120% 130% at 50% 30%, black 35%, transparent 95%);

--- a/src/lib/components/channel-card.svelte
+++ b/src/lib/components/channel-card.svelte
@@ -3,7 +3,8 @@
 	import {relativeDateDetailed} from '$lib/dates'
 	import * as m from '$lib/paraglide/messages'
 	import {trimWithEllipsis} from '$lib/utils'
-	import {playChannel, togglePlayPause} from '$lib/api'
+	import {toggleChannelPlay} from '$lib/api'
+	import {findChannelDeck} from '$lib/deck'
 	import {joinBroadcast} from '$lib/broadcast.js'
 	import {broadcastsCollection} from '$lib/collections/broadcasts'
 	import ChannelAvatar from './channel-avatar.svelte'
@@ -21,22 +22,29 @@
 		(broadcastsCollection.state.size, broadcastsCollection.state.has(channel.id))
 	)
 
-	const isPlaying = $derived(
-		Object.values(appState.decks).some((d) => d.playlist_slug === channel.slug && d.is_playing)
+	// Resolve the deck holding this channel once, then drive both display and action
+	// from it — so "pause" on the button always toggles the deck it's showing.
+	const channelDeck = $derived(
+		findChannelDeck(appState.decks, appState.active_deck_id, channel.slug)
 	)
+	const isPlaying = $derived(Boolean(channelDeck?.is_playing))
+
+	let playLoading = $state(false)
 
 	/** @param {MouseEvent} [event] */
-	function triggerPrimaryAction(event) {
+	async function triggerPrimaryAction(event) {
 		event?.preventDefault()
 		if (isBroadcasting) {
 			joinBroadcast(appState.active_deck_id, channel.id)
 			return
 		}
-		if (isPlaying) {
-			togglePlayPause(appState.active_deck_id)
-			return
+		if (playLoading) return
+		playLoading = true
+		try {
+			await toggleChannelPlay(channel)
+		} finally {
+			playLoading = false
 		}
-		playChannel(appState.active_deck_id, channel)
 	}
 
 	/** @param {MouseEvent} e */

--- a/src/lib/components/channel-micro-card.svelte
+++ b/src/lib/components/channel-micro-card.svelte
@@ -2,8 +2,8 @@
 	import {resolve} from '$app/paths'
 	import ChannelAvatar from '$lib/components/channel-avatar.svelte'
 
-	/** @type {{channel?: import('$lib/types').Channel, slug?: string | null, href?: string | undefined, className?: string}} */
-	let {channel, slug: slugProp, href, className = ''} = $props()
+	/** @type {{channel?: import('$lib/types').Channel, slug?: string | null, href?: string | undefined, class?: string}} */
+	let {channel, slug: slugProp, href, class: className = ''} = $props()
 
 	let effectiveSlug = $derived(channel?.slug ?? slugProp)
 	let linkHref = $derived(

--- a/src/lib/components/deck-channel-header.svelte
+++ b/src/lib/components/deck-channel-header.svelte
@@ -3,7 +3,6 @@
 	import Icon from '$lib/components/icon.svelte'
 	import AutoRadioButton from '$lib/components/auto-radio-button.svelte'
 	import Tag from '$lib/components/tag.svelte'
-	import PresenceCount from '$lib/components/presence-count.svelte'
 	import {deckTitle} from '$lib/deck'
 	import {extractHashtags, HASH_PREFIX_REGEX} from '$lib/utils'
 	import * as m from '$lib/paraglide/messages'
@@ -55,7 +54,6 @@
 	const broadcastSyncTitle = $derived(
 		broadcastSyncDrifted ? m.player_sync_broadcast() : m.player_broadcast_synced()
 	)
-	const autoTitle = $derived(deck?.auto_radio_drifted ? m.auto_radio_resync() : m.auto_radio_join())
 	const slugHref = (s) => (s ? resolve('/[slug]', {slug: s}) : undefined)
 	const resolvedSlugHref = $derived(slugHref(slug))
 	const resolvedChannelSlugHref = $derived(slugHref(channel?.slug))
@@ -129,16 +127,13 @@
 
 		{#if showModeMeta && showAutoButton}
 			<AutoRadioButton
-				className="auto-btn active"
-				synced={!!deck?.is_playing && !deck?.auto_radio_drifted}
-				title={autoTitle}
-				ariaLabel={autoTitle}
+				class="auto-btn"
+				live
+				drifted={!!deck?.auto_radio_drifted}
 				size={14}
+				count={presenceCount}
 				onclick={onAutoClick}
 			/>
-		{/if}
-		{#if showModeMeta && presenceCount > 0}
-			<PresenceCount count={presenceCount} />
 		{/if}
 	</div>
 </div>

--- a/src/lib/components/deck-compact-bar.svelte
+++ b/src/lib/components/deck-compact-bar.svelte
@@ -1,4 +1,5 @@
 <script>
+	import {untrack} from 'svelte'
 	import {goto} from '$app/navigation'
 	import {resolve} from '$app/paths'
 	import {appState, canEditChannel, removeDeck} from '$lib/app-state.svelte'
@@ -20,6 +21,7 @@
 	import {parseUrl} from 'media-now/parse-url'
 	import * as m from '$lib/paraglide/messages'
 	import Icon from '$lib/components/icon.svelte'
+	import AutoRadioButton from '$lib/components/auto-radio-button.svelte'
 	import ChannelMicroCard from '$lib/components/channel-micro-card.svelte'
 	import TrackCard from '$lib/components/track-card.svelte'
 	import SpeedControl from '$lib/components/speed-control.svelte'
@@ -44,7 +46,9 @@
 		!deck?.listening_to_channel_id || listeningDeckIds[0] === deckId
 	)
 
-	const display = createDeckDisplay(deckId)
+	// deckId never changes for this component instance — it's rendered inside
+	// an {#each ... (deckId)} keyed block, so a changed deckId remounts it.
+	const display = createDeckDisplay(untrack(() => deckId))
 	const track = $derived(display.track)
 	const displayTrack = $derived(display.displayTrack)
 	const displayChannel = $derived(display.displayChannel)
@@ -114,7 +118,7 @@
 			{mediaDuration}
 			trackDuration={displayTrack?.duration}
 			isPlaying={Boolean(deck?.is_playing)}
-			disabled={Boolean(deck?.listening_to_channel_id || deck?.auto_radio)}
+			disabled={Boolean(deck?.listening_to_channel_id)}
 			onseek={(val) => {
 				if (deck) deck.media_current_time = val
 				const mediaElement = getMediaPlayer(deckId)
@@ -209,7 +213,6 @@
 				<SpeedControl {deckId} {provider} />
 				<VolumeControl {deckId} />
 			{:else if deck?.auto_radio}
-				{@const autoNotSynced = !!deck?.auto_radio_drifted}
 				<button
 					class="play"
 					class:active={deck?.is_playing}
@@ -219,20 +222,13 @@
 				>
 					<Icon icon={deck?.is_playing ? 'pause' : 'play-fill'} />
 				</button>
-				<button
-					class="auto-sync"
-					class:active={!autoNotSynced}
-					title={autoNotSynced ? m.auto_radio_resync() : m.auto_radio_join()}
-					aria-label={autoNotSynced ? m.auto_radio_resync() : m.auto_radio_join()}
+				<AutoRadioButton
+					live
+					drifted={!!deck?.auto_radio_drifted}
+					size={14}
+					count={modePresenceCount}
 					onclick={() => resyncAutoRadio(deckId)}
-				>
-					<Icon icon="infinite" size={12} />
-					<span class="auto-sync-label">{autoNotSynced ? 'sync' : 'auto'}</span>
-					<span class="live-circle" aria-hidden="true">◉</span>
-					{#if modePresenceCount > 0}
-						<span class="live-count">{modePresenceCount}</span>
-					{/if}
-				</button>
+				/>
 			{:else if !deck?.listening_to_channel_id}
 				<VolumeControl {deckId} />
 			{/if}
@@ -341,10 +337,6 @@
 		display: none;
 	}
 
-	.controls .auto-sync.active :global(svg) {
-		color: var(--accent-9);
-	}
-
 	.controls :global(.speed),
 	.controls :global(.volume) {
 		flex: 1 1 7rem;
@@ -429,30 +421,6 @@
 			flex: 1 1 auto;
 			width: 100%;
 			flex-wrap: nowrap;
-		}
-
-		.controls .auto-sync {
-			flex: 1 1 auto;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			gap: var(--space-1);
-			overflow: hidden;
-		}
-
-		.controls .auto-sync .auto-sync-label {
-			font-size: var(--font-1);
-			white-space: nowrap;
-		}
-
-		.controls .auto-sync .live-circle {
-			font-size: 0.55em;
-			color: var(--accent-9);
-		}
-
-		.controls .auto-sync .live-count {
-			font-size: var(--font-1);
-			color: var(--gray-11);
 		}
 
 		.controls :global(.speed),

--- a/src/lib/components/icon.svelte
+++ b/src/lib/components/icon.svelte
@@ -77,8 +77,8 @@
 	} from 'obra-icons-svelte'
 	import IconDeckPanel from '$lib/components/icon-deck-panel.svelte'
 
-	/** @type {{icon: string, title?: string, className?: string, size?: string | number, children?: any, [key: string]: any}} */
-	const {children, icon = '', title, className = '', size = 18, ...rest} = $props()
+	/** @type {{icon: string, title?: string, class?: string, size?: string | number, children?: any, [key: string]: any}} */
+	const {children, icon = '', title, class: className = '', size = 18, ...rest} = $props()
 
 	const icons = {
 		book: IconBook,

--- a/src/lib/components/player.svelte
+++ b/src/lib/components/player.svelte
@@ -28,7 +28,7 @@
 	import {appState, canEditChannel, removeDeck, deckAccent} from '$lib/app-state.svelte'
 	import ChannelMicroCard from '$lib/components/channel-micro-card.svelte'
 	import Icon from '$lib/components/icon.svelte'
-	import PresenceCount from '$lib/components/presence-count.svelte'
+	import AutoRadioButton from '$lib/components/auto-radio-button.svelte'
 	import PopoverMenu from '$lib/components/popover-menu.svelte'
 	import SpeedControl from '$lib/components/speed-control.svelte'
 	import VolumeControl from '$lib/components/volume-control.svelte'
@@ -84,7 +84,9 @@
 	let soundcloudPlayer = $state()
 	let audioPlayer = $state()
 
-	const display = createDeckDisplay(deckId)
+	// deckId never changes for this component instance — it's rendered inside
+	// an {#each ... (deckId)} keyed block, so a changed deckId remounts it.
+	const display = createDeckDisplay(untrack(() => deckId))
 	const track = $derived(display.track)
 	const channel = $derived(display.channel)
 	const displayTrack = $derived(display.displayTrack)
@@ -671,7 +673,7 @@
 				{mediaDuration}
 				trackDuration={track?.duration}
 				isPlaying={Boolean(deck?.is_playing)}
-				disabled={isListeningToBroadcast || Boolean(deck?.auto_radio)}
+				disabled={isListeningToBroadcast}
 				onseek={(val) => {
 					if (deck) deck.media_current_time = val
 					if (mediaElement) mediaElement.currentTime = val
@@ -732,30 +734,16 @@
 					<VolumeControl {deckId} />
 				{:else if deck?.auto_radio}
 					{@render btnPlay()}
+					<AutoRadioButton
+						live
+						drifted={!!deck?.auto_radio_drifted}
+						size={14}
+						count={headerPresenceCount}
+						onclick={() => resyncAutoRadio(deckId)}
+					/>
 					<VolumeControl {deckId} />
 				{/if}
 			</menu>
-		{/if}
-		{#if deck?.auto_radio}
-			{@const autoNotSynced = !!deck?.auto_radio_drifted}
-			<div class="sync-footer">
-				<button
-					class={['sync-btn', {active: !autoNotSynced}]}
-					title={autoNotSynced ? m.auto_radio_resync() : m.auto_radio_join()}
-					aria-label={autoNotSynced ? m.auto_radio_resync() : m.auto_radio_join()}
-					onclick={() => resyncAutoRadio(deckId)}
-					{@attach tooltip({
-						content: autoNotSynced ? m.auto_radio_resync() : m.auto_radio_join(),
-						position: 'top'
-					})}
-				>
-					<Icon icon="infinite" size={14} />
-					<span>{autoNotSynced ? 'Sync' : 'Auto'}</span>
-					{#if headerPresenceCount > 0}
-						<PresenceCount count={headerPresenceCount} />
-					{/if}
-				</button>
-			</div>
 		{/if}
 	</section>
 </div>
@@ -873,24 +861,6 @@
 		justify-content: center;
 		padding-inline: var(--space-1);
 		min-height: 1.35rem;
-	}
-
-	.sync-footer {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		padding: 0 0.5rem 0.5rem;
-	}
-
-	.sync-footer .sync-btn {
-		width: 100%;
-		min-height: 1.7rem;
-		gap: var(--space-1);
-		justify-content: center;
-	}
-
-	.sync-footer .sync-btn.active :global(svg) {
-		color: var(--accent-9);
 	}
 
 	.layout-controls {

--- a/src/lib/components/search-track-menu.svelte
+++ b/src/lib/components/search-track-menu.svelte
@@ -72,7 +72,8 @@
 	</ButtonFeedback>
 	{#if canShowAutoRadio}
 		<AutoRadioButton
-			synced={isSearchAutoActive && isSearchAutoPlaying && !isSearchAutoDrifted}
+			live={isSearchAutoActive && isSearchAutoPlaying}
+			drifted={isSearchAutoDrifted}
 			title={isSearchAutoDrifted ? m.auto_radio_resync() : m.search_auto_radio_this()}
 			onclick={() => joinAutoRadio(appState.active_deck_id, autoRadioTracks, view)}
 		/>

--- a/src/lib/deck.ts
+++ b/src/lib/deck.ts
@@ -64,6 +64,22 @@ export function findChannelPlayingDeck(
 	return deckValues(decks).find((d) => d.playlist_slug === slug && d.is_playing)
 }
 
+/**
+ * Find the deck holding a channel slug — the re-tap target for "play this channel".
+ * Prefer the active deck, then a deck currently playing the slug, then any loaded deck.
+ * Resolving display and action through this one helper keeps them on the same deck.
+ */
+export function findChannelDeck(
+	decks: Record<number, Deck>,
+	activeDeckId: number,
+	slug?: string
+): Deck | undefined {
+	if (!slug) return undefined
+	const active = decks[activeDeckId]
+	if (active?.playlist_slug === slug) return active
+	return findPlayingDeck(decks, slug) ?? findLoadedDeck(decks, slug)
+}
+
 /** Find a deck listening to a channel (by channel ID), preferring active deck. */
 export function findListeningDeck(
 	decks: Record<number, Deck>,

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -88,7 +88,17 @@ async function preload() {
 			spamDecisionsCollection,
 			captureEventsCollection,
 			queue,
-			api
+			api,
+			// Deterministic deck probe for testing: which deck is active and what each holds.
+			// Prefer this over reading `is_playing` audio in headless — see browser-testing.md.
+			decks: () =>
+				Object.values(appState.decks).map((d) => ({
+					id: d.id,
+					slug: d.playlist_slug,
+					playing: d.is_playing,
+					active: d.id === appState.active_deck_id,
+					auto: d.auto_radio
+				}))
 		}
 	} catch (err) {
 		log.error('preloading_error', err)

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -239,23 +239,6 @@
 </script>
 
 <QueryClientProvider client={queryClient}>
-	<svg class="auto-live-gradient-defs" width="0" height="0" aria-hidden="true" focusable="false">
-		<defs>
-			<linearGradient id="r5-auto-live-gradient" x1="0" y1="0" x2="1" y2="0">
-				<stop offset="0" stop-color="var(--accent-8)" />
-				<stop offset="0.5" stop-color="var(--accent-11)" />
-				<stop offset="1" stop-color="var(--accent-8)" />
-				<animateTransform
-					attributeName="gradientTransform"
-					type="rotate"
-					from="0 0.5 0.5"
-					to="360 0.5 0.5"
-					dur="2.2s"
-					repeatCount="indefinite"
-				/>
-			</linearGradient>
-		</defs>
-	</svg>
 	<svelte:boundary>
 		{#await data.preloading}
 			<div class="loader">
@@ -364,14 +347,6 @@
 </QueryClientProvider>
 
 <style>
-	.auto-live-gradient-defs {
-		position: absolute;
-		width: 0;
-		height: 0;
-		overflow: hidden;
-		pointer-events: none;
-	}
-
 	.layout {
 		display: flex;
 		flex-direction: row;

--- a/src/routes/[slug]/+layout.svelte
+++ b/src/routes/[slug]/+layout.svelte
@@ -14,15 +14,13 @@
 	import {tracksCollection, checkTracksFreshness, ensureTracksLoaded} from '$lib/collections/tracks'
 	import {channelsCollection} from '$lib/collections/channels'
 	import {broadcastsCollection} from '$lib/collections/broadcasts'
+	import {getMediaPlayer, playChannel, shufflePlayChannel, toggleChannelPlay} from '$lib/api'
 	import {
-		getMediaPlayer,
-		joinAutoRadio,
-		playChannel,
-		resyncAutoRadio,
-		togglePlayPause
-	} from '$lib/api'
-	import {hasAutoRadioCoverage} from '$lib/player/auto-radio'
-	import {findAutoDecksForChannel, findChannelPlayingDeck, findListeningDeck} from '$lib/deck'
+		findAutoDecksForChannel,
+		findChannelDeck,
+		findChannelPlayingDeck,
+		findListeningDeck
+	} from '$lib/deck'
 	import ButtonFollow from '$lib/components/button-follow.svelte'
 	import ChannelAvatar from '$lib/components/channel-avatar.svelte'
 	import ChannelCanvasBg from '$lib/components/channel-canvas-bg.svelte'
@@ -154,16 +152,14 @@
 	let channelListeningDeck = $derived(
 		findListeningDeck(appState.decks, appState.active_deck_id, channel?.id)
 	)
-	let activeDeck = $derived(appState.decks[appState.active_deck_id])
-	let isChannelLoaded = $derived(
-		Boolean(channel?.slug && activeDeck?.playlist_slug === channel.slug)
+	// The deck the play button shows and acts on — resolved by channel, not "active",
+	// so display and action never drift to different decks. Same helper toggleChannelPlay uses.
+	let channelDeck = $derived(
+		findChannelDeck(appState.decks, appState.active_deck_id, channel?.slug)
 	)
-	let isChannelPlaying = $derived(Boolean(isChannelLoaded && activeDeck?.is_playing))
-	let isAutoEnabled = $derived(
-		Boolean(activeDeck?.auto_radio && activeDeck?.playlist_slug === slug)
-	)
-	let canShowAutoButton = $derived(hasAutoRadioCoverage(allChannelTracks))
-	let activeAutoDrifted = $derived(Boolean(isAutoEnabled && activeDeck?.auto_radio_drifted))
+	let isChannelPlaying = $derived(Boolean(channelDeck?.is_playing))
+	let isAutoEnabled = $derived(Boolean(channelDeck?.auto_radio))
+	let activeAutoDrifted = $derived(Boolean(isAutoEnabled && channelDeck?.auto_radio_drifted))
 	let autoPresenceCount = $derived(
 		channel?.slug ? (channelPresence[channel.slug]?.byUri?.[`@${channel.slug}`] ?? 0) : 0
 	)
@@ -173,9 +169,22 @@
 	let playLoading = $state(false)
 	let liveLoading = $state(false)
 	let userChannelSlug = $derived(appState.channel?.slug ?? '')
-	let playTooltip = $derived(isChannelPlaying ? m.player_tooltip_pause() : m.player_tooltip_play())
+	let playTooltip = $derived(
+		activeAutoDrifted
+			? m.auto_radio_resync()
+			: isChannelPlaying
+				? m.player_tooltip_pause()
+				: m.player_tooltip_play()
+	)
 	let playLabel = $derived(
-		playTooltip
+		(isChannelPlaying ? m.player_tooltip_pause() : m.player_tooltip_play())
+			.replace(/\s*<kbd>[^<]*<\/kbd>/gi, '')
+			.replace(/<[^>]+>/g, '')
+			.trim()
+	)
+	let shuffleLabel = $derived(
+		m
+			.player_tooltip_shuffle()
 			.replace(/\s*<kbd>[^<]*<\/kbd>/gi, '')
 			.replace(/<[^>]+>/g, '')
 			.trim()
@@ -259,34 +268,26 @@
 		}
 	}
 
+	// Decision tree (resync/pause/resume/start) lives in toggleChannelPlay.
+	// Pass tid so track-detail pages start from the viewed track.
 	async function onPlayAction() {
 		if (!channel || playLoading) return
-		if (isChannelLoaded) {
-			togglePlayPause(appState.active_deck_id)
-			return
-		}
 		playLoading = true
 		try {
-			await playChannel(appState.active_deck_id, channel, tid)
+			await toggleChannelPlay(channel, tid)
 		} finally {
 			playLoading = false
 		}
 	}
 
-	async function onAutoAction() {
-		if (!channel) return
-		const deckId = appState.active_deck_id
-		const deck = appState.decks[deckId]
-		if (deck?.listening_to_channel_id) {
-			leaveBroadcast(deckId)
+	async function onShuffleAction() {
+		if (!channel || playLoading) return
+		playLoading = true
+		try {
+			await shufflePlayChannel(appState.active_deck_id, channel)
+		} finally {
+			playLoading = false
 		}
-		if (deck?.auto_radio && deck.playlist_slug === slug) {
-			void resyncAutoRadio(deckId)
-			return
-		}
-		await ensureTracksLoaded(slug)
-		const tracks = [...tracksCollection.state.values()].filter((t) => t.slug === slug)
-		await joinAutoRadio(deckId, tracks, {sources: [{channels: [slug]}]})
 	}
 
 	// --- Context providers ---
@@ -439,32 +440,33 @@
 							</button>
 						{/if}
 
-						{#if canShowAutoButton}
-							<button
-								type="button"
-								class={['mode-action', 'auto', {active: isAutoEnabled, drifted: activeAutoDrifted}]}
-								onclick={onAutoAction}
-								{@attach tooltip({
-									content: activeAutoDrifted ? m.auto_radio_resync() : m.auto_radio_join()
-								})}
-							>
-								<Icon icon="infinite" size={14} />
-								<span>Auto</span>
-								{#if autoPresenceCount > 0}
-									<PresenceCount count={autoPresenceCount} />
-								{/if}
-							</button>
-						{/if}
-
 						<button
 							type="button"
-							class={['mode-action', 'play', {active: isChannelPlaying}]}
+							class={[
+								'mode-action',
+								'play',
+								{active: isChannelPlaying, drifted: activeAutoDrifted}
+							]}
 							onclick={onPlayAction}
 							disabled={playLoading}
 							{@attach tooltip({content: playTooltip})}
 						>
 							<Icon icon={isChannelPlaying ? 'pause' : 'play-fill'} size={14} />
 							<span>{playLabel}</span>
+							{#if autoPresenceCount > 0}
+								<PresenceCount count={autoPresenceCount} />
+							{/if}
+						</button>
+
+						<button
+							type="button"
+							class={['mode-action', 'shuffle']}
+							onclick={onShuffleAction}
+							disabled={playLoading}
+							{@attach tooltip({content: m.channels_tooltip_shuffle()})}
+						>
+							<Icon icon="shuffle" size={14} />
+							<span>{shuffleLabel}</span>
 						</button>
 					</menu>
 				</div>
@@ -576,10 +578,6 @@
 		line-height: 1.1;
 		margin: 0;
 		transition: color 0.15s;
-	}
-
-	.info :global(.channel-page-title.active) {
-		color: var(--accent-9);
 	}
 
 	.info :global(.meta-row) {

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -375,7 +375,8 @@
 			</button>
 			{#if hasAutoRadioCoverage(tagFilteredTracks)}
 				<AutoRadioButton
-					synced={isAutoActive && isAutoPlaying && !isAutoDrifted}
+					live={isAutoActive && isAutoPlaying}
+					drifted={isAutoDrifted}
 					title={isAutoDrifted ? m.auto_radio_resync() : m.auto_radio_join()}
 					onclick={() =>
 						autoView &&

--- a/src/routes/[slug]/tracks/+page.svelte
+++ b/src/routes/[slug]/tracks/+page.svelte
@@ -327,7 +327,8 @@
 			>
 			{#if channel && canShowFilteredAutoRadio}
 				<AutoRadioButton
-					synced={isFilteredAutoActive && isFilteredAutoPlaying && !isFilteredAutoDrifted}
+					live={isFilteredAutoActive && isFilteredAutoPlaying}
+					drifted={isFilteredAutoDrifted}
 					title={isFilteredAutoDrifted ? m.auto_radio_resync() : m.tracks_auto_radio_selection()}
 					onclick={() =>
 						joinAutoRadio(appState.active_deck_id, filteredAutoRadioTracks, filteredAutoView)}

--- a/src/routes/docs/styles/buttons/+page.svelte
+++ b/src/routes/docs/styles/buttons/+page.svelte
@@ -184,20 +184,17 @@
 	<h2>Auto radio (<code>&lt;AutoRadioButton&gt;</code> / <code>.auto-live-btn</code>)</h2>
 	<p>
 		<small
-			>Infinite icon whose stroke uses an animated gradient. Idle is a plain button; when
-			<code>synced</code> it goes <code>.ghost</code> and the stroke animates.</small
+			>Infinite-icon button for auto-radio. Idle is a plain button; <code>live</code> turns it
+			active; <code>drifted</code> drops it back to a resync call-to-action. A <code>count</code>
+			above 1 shows a listener badge in the corner.</small
 		>
 	</p>
 	<div class="row">
 		<AutoRadioButton title="Idle" />
-		<AutoRadioButton synced title="Synced (animated)" />
-		<button class="auto-live-btn active"><Icon icon="infinite" size={16} /></button>
+		<AutoRadioButton live title="Live" />
+		<AutoRadioButton live drifted title="Drifted (resync)" />
+		<AutoRadioButton live count={3} title="Live with listeners" />
 	</div>
-	<p>
-		<small
-			>Last one: <code>.auto-live-btn.active</code> (drifted) — solid accent stroke, no animation.</small
-		>
-	</p>
 </section>
 
 <section>

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -112,25 +112,6 @@ button.ghost.active,
 	}
 }
 
-button.auto-live-btn.ghost .oi-infinite .oi-vector,
-.btn.auto-live-btn.ghost .oi-infinite .oi-vector {
-	stroke: var(--accent-9);
-	/* biome-ignore lint/suspicious/noDuplicateProperties: intentional fallback — color for browsers that don't support gradient URLs */
-	stroke: url('#r5-auto-live-gradient');
-}
-
-/* active + drifted: solid accent stroke (no animation) */
-button.auto-live-btn.active:not(.ghost) .oi-infinite .oi-vector {
-	stroke: var(--accent-9);
-}
-
-@media (prefers-reduced-motion: reduce) {
-	button.auto-live-btn.ghost .oi-infinite .oi-vector,
-	.btn.auto-live-btn.ghost .oi-infinite .oi-vector {
-		stroke: var(--accent-9);
-	}
-}
-
 button[data-loading='true'] {
 	cursor: wait;
 }

--- a/src/styles/buttons.css
+++ b/src/styles/buttons.css
@@ -241,7 +241,7 @@ button.icon-label-right {
 	background: var(--color-red);
 }
 
-.mode-action.auto.drifted {
+.mode-action.drifted {
 	color: var(--orange-9);
 }
 


### PR DESCRIPTION
A few different fixes/improvements while browsing and playing the app again.

## Playing channels and auto-radio

Historically playing a channel has always meant playing the newest track. But now, with the recent improvement in technology™️ and auto-radio ™️  , tapping play on a channel will _tune in_ in to auto-radio mode. If the channel doesn't support auto-radio, it'll fall back to newest track as before. I also added a "Play random" button next to it, and tried to simplify the auto radio button to be a single icon. Can still be improved for sure.

## Deck progress bar is enabled by default

I also completely forgot that we had a progress bar. I enabled it by default, especially for the compact deck it's nice to have it, as it's the only way to see whether the track is really progressing/playing.