### PR TITLE
Fix track page meta title fallback (and channel title fallbacks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## July 2026
+
+- #Channels Track page title shows the track's name — or "Track" when it has none — instead of the placeholder "title"
+
 ## June 2026
 
 - #Home Featured tracks rotate daily and include more channels

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -757,6 +757,7 @@
 	"track_meta_view_discogs": "view on discogs →",
 	"track_meta_view_musicbrainz": "view on musicbrainz →",
 	"track_not_found": "Track not found",
+	"track_page_fallback": "Track",
 	"track_play_next": "Queue",
 	"track_recently_saved": "Recently saved tracks",
 	"track_related_by": "by",

--- a/src/routes/[slug]/followers/+page.svelte
+++ b/src/routes/[slug]/followers/+page.svelte
@@ -100,7 +100,7 @@
 {/snippet}
 
 <svelte:head>
-	<title>{m.nav_followers()} - {channel?.name}</title>
+	<title>{m.nav_followers()} - {channel?.name || m.channel_page_fallback()}</title>
 </svelte:head>
 
 <article class="channels-page fill-height">

--- a/src/routes/[slug]/followers/in-common/+page.svelte
+++ b/src/routes/[slug]/followers/in-common/+page.svelte
@@ -104,7 +104,7 @@
 {/snippet}
 
 <svelte:head>
-	<title>{m.nav_in_common()} - {channel?.name}</title>
+	<title>{m.nav_in_common()} - {channel?.name || m.channel_page_fallback()}</title>
 </svelte:head>
 
 <article class="channels-page fill-height">

--- a/src/routes/[slug]/following/+page.svelte
+++ b/src/routes/[slug]/following/+page.svelte
@@ -163,7 +163,7 @@
 {/snippet}
 
 <svelte:head>
-	<title>{m.nav_following()} - {channel?.name}</title>
+	<title>{m.nav_following()} - {channel?.name || m.channel_page_fallback()}</title>
 </svelte:head>
 
 <article class="channels-page fill-height">

--- a/src/routes/[slug]/following/featured/+page.svelte
+++ b/src/routes/[slug]/following/featured/+page.svelte
@@ -173,7 +173,7 @@
 {/snippet}
 
 <svelte:head>
-	<title>{m.channel_section_featured_channels()} - {channel?.name}</title>
+	<title>{m.channel_section_featured_channels()} - {channel?.name || m.channel_page_fallback()}</title>
 </svelte:head>
 
 <article class="channels-page fill-height">

--- a/src/routes/[slug]/following/in-common/+page.svelte
+++ b/src/routes/[slug]/following/in-common/+page.svelte
@@ -168,7 +168,7 @@
 {/snippet}
 
 <svelte:head>
-	<title>{m.nav_in_common()} - {channel?.name}</title>
+	<title>{m.nav_in_common()} - {channel?.name || m.channel_page_fallback()}</title>
 </svelte:head>
 
 <article class="channels-page fill-height">

--- a/src/routes/[slug]/tracks/[tid]/(tabs)/+layout.svelte
+++ b/src/routes/[slug]/tracks/[tid]/(tabs)/+layout.svelte
@@ -97,7 +97,7 @@
 </script>
 
 <Seo
-	title={track?.title || m.track_meta_title()}
+	title={track?.title || m.track_page_fallback()}
 	description={track?.description}
 	image={ogImage}
 	url={page.url.href}

--- a/src/routes/[slug]/tracks/[tid]/delete/+page.svelte
+++ b/src/routes/[slug]/tracks/[tid]/delete/+page.svelte
@@ -55,7 +55,7 @@
 </script>
 
 <svelte:head>
-	<title>{m.common_delete()} {track?.title || m.track_meta_title()}</title>
+	<title>{m.common_delete()} {track?.title || m.track_page_fallback()}</title>
 </svelte:head>
 
 <article class="constrained focused">


### PR DESCRIPTION
## Problem

On a track detail route like `/wavs/tracks/<id>/youtube`, the meta title rendered as **`title | Radio4000`** instead of the track's title.

Cause: the track detail layout and the track delete page used `m.track_meta_title()` as the fallback for the page/OG title. That message is a **field label** — the literal word "title" (used correctly elsewhere as a `<dt>` label and a nav `aria-label`). Because `||` treats an empty string as falsy, any track with an empty title (valid, if unusual) — or a track that's still loading — fell through to that label and showed "title".

## Fix

- Added a proper `track_page_fallback` message (`"Track"`), mirroring the existing `channel_page_fallback` (`"Channel"`) pattern. Only `en.json` needs it — `i18n/sync.js` confirms other locales fall back to English.
- Used it in the track detail layout (`Seo` title) and the track delete page.

Now:
- Track with a real title → shows the title (unchanged).
- Track with an empty/loading title → shows **`Track | Radio4000`** instead of `title | Radio4000`.

## Related cleanup

While checking whether other meta titles had the same class of issue, I found the follower/following channel sub-pages rendered a bare `{channel?.name}` with no fallback — producing a dangling `"Followers - "` on a deep link (before the channel loads) or an unresolved slug. Their sibling channel pages (`edit`, `delete`, `batch-edit`, `trackids`) already use `channel?.name || m.channel_page_fallback()`, so I applied the same fallback to:

- `[slug]/followers`
- `[slug]/followers/in-common`
- `[slug]/following`
- `[slug]/following/featured`
- `[slug]/following/in-common`

No other meta titles use a field label as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014rNDqVPpUwCURJL2MpVhEc)_