### PR TITLE
Adopt Seo everywhere, slim down the homepage

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -4,14 +4,9 @@ Possible improvements. Roughly by priority. Verify before implementing.
 
 Last update (2026-05-27): cleared done sections — see CHANGELOG.md for user-facing history.
 
-## Simplify: rely on types and primitives, fewer layers
-
-- **Broadcast field juggling** — `broadcast.js`: `pickBroadcastFields()`, `getBroadcastDeckState()`, ephemeral track construction. Three hand-rolled serializers. Align types so most disappear.
-- **Player vs compact bar: same concept, two local contracts** — `player.svelte` and `deck-compact-bar.svelte` each rebuild "what this deck is showing" with different rules. Both keep their own `lastTrack`/`lastChannel`, both derive display fallbacks, both resolve header channel differently. Extract one shared derivation.
-
 ## Backlog
 
-- Consolidate page metadata behind `src/lib/components/seo.svelte` — today some routes use raw `<svelte:head>` because `Seo` always appends `| {appName}` and emits OG tags, while many title messages already hardcode `Radio4000` or custom formatting. Refactor `Seo` into the single metadata path for non-debug routes: support plain/full titles, stop baking brand names into i18n title strings, move default title/description in `src/app.html` to config-driven values, and keep route usage consistent.
+- Page metadata follow-ups — `Seo` is now the single metadata path (50 routes migrated, `plain` prop skips the `| {appName}` suffix). Remaining: stop baking brand names into i18n title strings so more routes can drop `plain`, and move default title/description in `src/app.html` to config-driven values (needs a `transformPageChunk` hook in `hooks.server.ts`).
 - `userHasPlayed` not reset between playlists (`player.svelte`) — flag carries over when switching channels, may cause unexpected autoplay. Needs verification and user testing.
 - `seekWhenReady` race in `broadcast.js` — between the final `seekJobSeqByDeck` check and `play(deckId)`, a new job could start. Old job's `play()` still fires. Needs verification and user testing.
 

--- a/src/lib/components/featured-channels.svelte
+++ b/src/lib/components/featured-channels.svelte
@@ -1,0 +1,203 @@
+<script>
+	import {appState} from '$lib/app-state.svelte'
+	import {playChannel, togglePlayPause} from '$lib/api'
+	import {pickFeatured, dailySeed} from '$lib/collections/featured'
+	import {shuffleSeed} from '$lib/utils'
+	import ChannelCard from './channel-card.svelte'
+	import Icon from './icon.svelte'
+	import * as m from '$lib/paraglide/messages'
+
+	/** @type {{pool: import('$lib/types').Channel[], pickCount: number, titleHref?: string, skeleton?: boolean, column?: boolean}} */
+	let {pool, pickCount, titleHref, skeleton = false, column = false} = $props()
+
+	// Daily-seeded by default (same rotation as /featured); reshuffle picks a
+	// random seed for instant variety. Shared pickFeatured keeps both in sync.
+	let seed = $state(dailySeed())
+	let shuffling = $state(false)
+
+	const channels = $derived(pickFeatured(pool, {count: pickCount, seed}))
+	const first = $derived(channels[0] ?? null)
+	const isPlaying = $derived(
+		!!first &&
+			Object.values(appState.decks).some((d) => d.playlist_slug === first.slug && d.is_playing)
+	)
+
+	function togglePlay() {
+		if (!first) return
+		if (isPlaying) togglePlayPause(appState.active_deck_id)
+		else playChannel(appState.active_deck_id, first)
+	}
+
+	function reshuffle() {
+		if (!pool.length || shuffling) return
+		shuffling = true
+		try {
+			seed = shuffleSeed()
+		} finally {
+			shuffling = false
+		}
+	}
+</script>
+
+{#if channels.length}
+	<section class="section" class:section--featured-col={column}>
+		<header class="section-header">
+			<h2 class="section-title">
+				{#if titleHref}
+					<a class="btn chip" href={titleHref}>{m.home_featured()}</a>
+				{:else}
+					{m.home_featured()}
+				{/if}
+			</h2>
+			<menu>
+				{#if first}
+					<button type="button" onclick={togglePlay}>
+						<Icon icon={isPlaying ? 'pause' : 'play-fill'} />
+					</button>
+				{/if}
+				{#if pool.length > pickCount}
+					<button
+						type="button"
+						title={m.home_featured_refresh()}
+						onclick={reshuffle}
+						disabled={shuffling}
+					>
+						<Icon icon="switch-alt" />
+					</button>
+				{/if}
+			</menu>
+		</header>
+		<ol class="grid grid--scroll">
+			{#each channels as channel (channel.id)}
+				<li><ChannelCard {channel} /></li>
+			{/each}
+		</ol>
+	</section>
+{:else if skeleton}
+	<!-- Skeleton mirrors ChannelCard's height-driving structure (square figure +
+	     body) so the featured slot reserves its space before data loads, instead
+	     of popping in and shoving the globe down (CLS). -->
+	<section class="section" class:section--featured-col={column} aria-hidden="true">
+		<header class="section-header">
+			<h2 class="section-title">
+				{#if titleHref}
+					<a class="btn chip" href={titleHref}>{m.home_featured()}</a>
+				{:else}
+					{m.home_featured()}
+				{/if}
+			</h2>
+		</header>
+		<ol class="grid grid--scroll">
+			{#each Array.from({length: pickCount}) as _, i (i)}
+				<li>
+					<article class="card skeleton-card">
+						<div class="sk-figure"></div>
+						<div class="sk-body">
+							<div class="sk-line sk-title"></div>
+							<div class="sk-line sk-slug"></div>
+							<div class="sk-line sk-desc"></div>
+							<div class="sk-line sk-desc"></div>
+							<div class="sk-line sk-desc sk-desc--short"></div>
+							<div class="sk-line sk-meta"></div>
+						</div>
+					</article>
+				</li>
+			{/each}
+		</ol>
+	</section>
+{/if}
+
+<style>
+	.section--featured-col {
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-start;
+	}
+
+	.section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
+		.section-title {
+			margin-bottom: 0;
+		}
+	}
+
+	.section-title {
+		font-size: var(--font-7);
+		font-weight: 600;
+		margin-bottom: 0.5rem;
+		color: light-dark(var(--gray-11), var(--gray-9));
+	}
+
+	/* Featured loading skeleton — mirrors ChannelCard's structure so the slot height
+	   matches the real cards and nothing shifts when they load. */
+	.skeleton-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		padding: var(--space-1);
+		height: 100%;
+	}
+
+	.sk-figure {
+		aspect-ratio: 1;
+		width: 100%;
+		border-radius: var(--border-radius);
+		background: var(--gray-2);
+	}
+
+	.sk-body {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-top: 0.5rem;
+		flex: 1;
+	}
+
+	.sk-line {
+		background: var(--gray-2);
+		border-radius: 4px;
+	}
+
+	.sk-title {
+		height: 1rem;
+		width: 70%;
+	}
+
+	.sk-slug {
+		height: 0.5rem;
+		width: 40%;
+	}
+
+	.sk-desc {
+		height: 0.5rem;
+		width: 92%;
+		margin-top: 0.5rem;
+	}
+
+	.sk-desc--short {
+		width: 60%;
+		margin-top: 0;
+	}
+
+	.sk-meta {
+		height: 0.5rem;
+		width: 30%;
+		margin-top: auto;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.skeleton-card .sk-figure,
+		.skeleton-card .sk-line {
+			animation: sk-pulse 1.4s ease-in-out infinite;
+		}
+	}
+
+	@keyframes sk-pulse {
+		50% {
+			opacity: 0.55;
+		}
+	}
+</style>

--- a/src/lib/components/home-globe.svelte
+++ b/src/lib/components/home-globe.svelte
@@ -1,0 +1,94 @@
+<script>
+	import {onMount} from 'svelte'
+	import Icon from './icon.svelte'
+	import * as m from '$lib/paraglide/messages'
+
+	/** @type {{channels: import('$lib/types').Channel[], zoom: number, overlayHref: string, compact?: boolean, onvisible?: () => void}} */
+	let {channels, zoom, overlayHref, compact = false, onvisible} = $props()
+
+	let section = $state(/** @type {HTMLDivElement | undefined} */ (undefined))
+	let visible = $state(false)
+	let HomeMapChannels = $state(
+		/** @type {typeof import('./map-channels.svelte').default | null} */ (null)
+	)
+
+	onMount(() => {
+		if (!section || visible) return
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (!entries.some((entry) => entry.isIntersecting)) return
+				visible = true
+				onvisible?.()
+				observer.disconnect()
+			},
+			{rootMargin: '400px 0px'}
+		)
+
+		observer.observe(section)
+		return () => observer.disconnect()
+	})
+
+	$effect(() => {
+		if (!visible || HomeMapChannels) return
+		void import('./map-channels.svelte').then((module) => {
+			HomeMapChannels = module.default
+		})
+	})
+</script>
+
+<div class="globe" class:compact bind:this={section}>
+	{#if HomeMapChannels && visible}
+		<HomeMapChannels {channels} globeMode={true} {zoom} syncUrl={false} showControls={false} />
+	{:else}
+		<div class="globe-placeholder" aria-hidden="true"></div>
+	{/if}
+	<a href={overlayHref} class="btn map-overlay-btn" aria-label={m.nav_map()}>
+		<Icon icon="fullscreen" size={14} />
+	</a>
+</div>
+
+<style>
+	.globe {
+		position: relative;
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		min-height: 50dvh;
+		margin-top: -0.75rem;
+		background: transparent;
+		border-radius: var(--border-radius);
+		overflow: hidden;
+		:global(.map) {
+			flex: 1;
+			min-height: 0;
+		}
+		:global(article .description) {
+			display: none;
+		}
+	}
+
+	.globe.compact {
+		max-height: 55dvh;
+		z-index: 0;
+	}
+
+	.globe-placeholder {
+		flex: 1;
+		min-height: 50dvh;
+		background:
+			radial-gradient(circle at 50% 42%, rgb(105 160 255 / 0.22), transparent 18%),
+			radial-gradient(circle at 50% 50%, rgb(36 72 126 / 0.85), rgb(9 15 24 / 0.95) 72%);
+	}
+
+	.map-overlay-btn {
+		position: absolute;
+		bottom: 0.5rem;
+		left: 0.5rem;
+		z-index: 10;
+		opacity: 0.7;
+		&:hover {
+			opacity: 1;
+		}
+	}
+</style>

--- a/src/lib/components/seo.svelte
+++ b/src/lib/components/seo.svelte
@@ -1,10 +1,10 @@
 <script>
 	import {appName} from '$lib/config'
-	let {title, description, image, url, type = 'website'} = $props()
+	let {title, description = undefined, image = undefined, url = undefined, type = 'website', plain = false} = $props()
 </script>
 
 <svelte:head>
-	<title>{title} | {appName}</title>
+	<title>{plain ? title : `${title} | ${appName}`}</title>
 	<meta property="og:site_name" content={appName} />
 	<meta property="og:title" content={title} />
 	<meta property="og:type" content={type} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script>
-	import {onMount} from 'svelte'
 	import {goto} from '$app/navigation'
 	import {resolve} from '$app/paths'
 	import {appState} from '$lib/app-state.svelte'
@@ -7,22 +6,24 @@
 	import {broadcastsCollection} from '$lib/collections/broadcasts'
 	import {channelsCollection} from '$lib/collections/channels'
 	import {useLiveQuery} from '$lib/useLiveQuery.svelte'
-	import {shuffleSeed} from '$lib/utils'
 	import {getFollowedChannels} from '$lib/followed-channels.svelte'
-	import {getFeaturedPool, pickFeatured, dailySeed} from '$lib/collections/featured'
+	import {getFeaturedPool} from '$lib/collections/featured'
 	import {tracksCollection, ensureTracksLoaded} from '$lib/collections/tracks'
 	import {getChannelTags, extractHashtags} from '$lib/utils'
-	import {playChannel, togglePlayPause, loadDeckView, playTrack, sortByNewest} from '$lib/api'
+	import {loadDeckView, playTrack, sortByNewest} from '$lib/api'
 	import {isBroadcasting} from '$lib/deck'
 	import {authStatus} from '$lib/app-state.svelte'
 	import {appPresence, watchPresence, unwatchPresence} from '$lib/presence.svelte'
 	import {sdk} from '@radio4000/sdk'
 	import ChannelCard from '$lib/components/channel-card.svelte'
+	import FeaturedChannels from '$lib/components/featured-channels.svelte'
+	import HomeGlobe from '$lib/components/home-globe.svelte'
 	import MyChannelControls from '$lib/components/my-channel-controls.svelte'
 	import {not, isNull, eq} from '@tanstack/db'
 	import Icon from '$lib/components/icon.svelte'
 	import PageHeader from '$lib/components/page-header.svelte'
 	import SearchInput from '$lib/components/search-input.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const FEATURED_COUNT = 3
@@ -57,24 +58,6 @@
 
 	const featuredPickCount = $derived(!isSignedIn ? FEATURED_COUNT_LOGGEDOUT : FEATURED_COUNT)
 
-	// Daily-seeded by default (same rotation as /featured); reshuffle picks a
-	// random seed for instant variety. Shared pickFeatured keeps both in sync.
-	let featuredSeed = $state(dailySeed())
-	let shuffling = $state(false)
-	function reshuffleFeatured() {
-		if (!featuredPool.length || shuffling) return
-		shuffling = true
-		try {
-			featuredSeed = shuffleSeed()
-		} finally {
-			shuffling = false
-		}
-	}
-
-	const featuredChannels = $derived(
-		pickFeatured(featuredPool, {count: featuredPickCount, seed: featuredSeed})
-	)
-
 	$effect(() => {
 		if (featuredLoaded) return
 		featuredLoaded = true
@@ -86,20 +69,6 @@
 			}
 		})()
 	})
-
-	const featuredFirst = $derived(featuredChannels[0] ?? null)
-	const featuredIsPlaying = $derived(
-		!!featuredFirst &&
-			Object.values(appState.decks).some(
-				(d) => d.playlist_slug === featuredFirst.slug && d.is_playing
-			)
-	)
-
-	function toggleFeaturedPlay() {
-		if (!featuredFirst) return
-		if (featuredIsPlaying) togglePlayPause(appState.active_deck_id)
-		else playChannel(appState.active_deck_id, featuredFirst)
-	}
 
 	// Live broadcasts — reactive via useLiveQuery, sorted by most recently active
 	const broadcastsQuery = useLiveQuery(broadcastsCollection)
@@ -186,41 +155,11 @@
 	const showFavoriteBroadcastWidget = $derived(favoriteBroadcastCount > 0)
 	const showBroadcastCountWidget = $derived(broadcastCount > 0 && !userChannelIsBroadcasting)
 
-	let homeMapSection = $state(/** @type {HTMLDivElement | undefined} */ (undefined))
 	let homeMapVisible = $state(false)
-	let HomeMapChannels = $state(
-		/** @type {typeof import('$lib/components/map-channels.svelte').default | null} */ (null)
-	)
-
-	onMount(() => {
-		const section = homeMapSection
-		if (!section || homeMapVisible) return
-
-		const observer = new IntersectionObserver(
-			(entries) => {
-				if (!entries.some((entry) => entry.isIntersecting)) return
-				homeMapVisible = true
-				observer.disconnect()
-			},
-			{rootMargin: '400px 0px'}
-		)
-
-		observer.observe(section)
-		return () => observer.disconnect()
-	})
-
-	$effect(() => {
-		if (!homeMapVisible || HomeMapChannels) return
-		void import('$lib/components/map-channels.svelte').then((module) => {
-			HomeMapChannels = module.default
-		})
-	})
-
-	const shouldLoadHomeMapData = $derived(homeMapVisible)
 
 	// Globe channels — all synced channels with coordinates
 	const globeChannelsQuery = useLiveQuery((q) =>
-		shouldLoadHomeMapData
+		homeMapVisible
 			? q.from({ch: channelsCollection}).where(({ch}) => not(isNull(ch.latitude)))
 			: null
 	)
@@ -257,9 +196,7 @@
 	})
 </script>
 
-<svelte:head>
-	<title>{m.home_title({appName})}</title>
-</svelte:head>
+<Seo title={m.home_title({appName})} plain />
 
 <div class="homepage" class:signed-in={isSignedIn}>
 	<PageHeader>
@@ -419,22 +356,12 @@
 		</section>
 
 		<section class="section section--globe">
-			<div class="globe" bind:this={homeMapSection}>
-				{#if HomeMapChannels && homeMapVisible}
-					<HomeMapChannels
-						channels={mapChannels}
-						globeMode={true}
-						zoom={1}
-						syncUrl={false}
-						showControls={false}
-					/>
-				{:else}
-					<div class="globe-placeholder" aria-hidden="true"></div>
-				{/if}
-				<a href={mapOverlayHref} class="btn map-overlay-btn" aria-label={m.nav_map()}>
-					<Icon icon="fullscreen" size={14} />
-				</a>
-			</div>
+			<HomeGlobe
+				channels={mapChannels}
+				zoom={1}
+				overlayHref={mapOverlayHref}
+				onvisible={() => (homeMapVisible = true)}
+			/>
 		</section>
 	{:else if isSignedIn && authStatus.channelChecked}
 		<!-- Logged in but no channel -->
@@ -462,35 +389,7 @@
 			</section>
 		{/if}
 
-		{#if featuredChannels.length}
-			<section class="section">
-				<header class="section-header">
-					<h2 class="section-title">{m.home_featured()}</h2>
-					<menu>
-						{#if featuredFirst}
-							<button type="button" onclick={toggleFeaturedPlay}>
-								<Icon icon={featuredIsPlaying ? 'pause' : 'play-fill'} />
-							</button>
-						{/if}
-						{#if featuredPool.length > featuredPickCount}
-							<button
-								type="button"
-								title={m.home_featured_refresh()}
-								onclick={reshuffleFeatured}
-								disabled={shuffling}
-							>
-								<Icon icon="switch-alt" />
-							</button>
-						{/if}
-					</menu>
-				</header>
-				<ol class="grid grid--scroll">
-					{#each featuredChannels as channel (channel.id)}
-						<li><ChannelCard {channel} /></li>
-					{/each}
-				</ol>
-			</section>
-		{/if}
+		<FeaturedChannels pool={featuredPool} pickCount={featuredPickCount} />
 	{:else}
 		<!-- Not logged in -->
 
@@ -542,65 +441,13 @@
 
 		<div class="loggedout-over-globe">
 			<div class="loggedout-grid">
-				{#if featuredChannels.length}
-					<section class="section section--featured-col">
-						<header class="section-header">
-							<h2 class="section-title">
-								<a class="btn chip" href={resolve('/channels/featured')}>{m.home_featured()}</a>
-							</h2>
-							<menu>
-								{#if featuredFirst}
-									<button type="button" onclick={toggleFeaturedPlay}>
-										<Icon icon={featuredIsPlaying ? 'pause' : 'play-fill'} />
-									</button>
-								{/if}
-								{#if featuredPool.length > featuredPickCount}
-									<button
-										type="button"
-										title={m.home_featured_refresh()}
-										onclick={reshuffleFeatured}
-										disabled={shuffling}
-									>
-										<Icon icon="switch-alt" />
-									</button>
-								{/if}
-							</menu>
-						</header>
-						<ol class="grid grid--scroll">
-							{#each featuredChannels as channel (channel.id)}
-								<li><ChannelCard {channel} /></li>
-							{/each}
-						</ol>
-					</section>
-				{:else}
-					<!-- Skeleton mirrors ChannelCard's height-driving structure (square figure +
-					     body) so the featured slot reserves its space before data loads, instead
-					     of popping in and shoving the globe down (CLS). -->
-					<section class="section section--featured-col" aria-hidden="true">
-						<header class="section-header">
-							<h2 class="section-title">
-								<a class="btn chip" href={resolve('/channels/featured')}>{m.home_featured()}</a>
-							</h2>
-						</header>
-						<ol class="grid grid--scroll">
-							{#each Array.from({length: featuredPickCount}) as _, i (i)}
-								<li>
-									<article class="card skeleton-card">
-										<div class="sk-figure"></div>
-										<div class="sk-body">
-											<div class="sk-line sk-title"></div>
-											<div class="sk-line sk-slug"></div>
-											<div class="sk-line sk-desc"></div>
-											<div class="sk-line sk-desc"></div>
-											<div class="sk-line sk-desc sk-desc--short"></div>
-											<div class="sk-line sk-meta"></div>
-										</div>
-									</article>
-								</li>
-							{/each}
-						</ol>
-					</section>
-				{/if}
+				<FeaturedChannels
+					pool={featuredPool}
+					pickCount={featuredPickCount}
+					titleHref={resolve('/channels/featured')}
+					skeleton
+					column
+				/>
 			</div>
 
 			{#if featuredLoaded && (channelCount || trackCount || appPresence.count)}
@@ -618,26 +465,13 @@
 		</div>
 
 		<section class="section section--globe section--globe--loggedout">
-			<div class="globe" bind:this={homeMapSection}>
-				{#if HomeMapChannels && homeMapVisible}
-					<HomeMapChannels
-						channels={globeChannels}
-						globeMode={true}
-						zoom={1.5}
-						syncUrl={false}
-						showControls={false}
-					/>
-				{:else}
-					<div class="globe-placeholder" aria-hidden="true"></div>
-				{/if}
-				<a
-					href={resolve('/channels/all') + '?display=map'}
-					class="btn map-overlay-btn"
-					aria-label={m.nav_map()}
-				>
-					<Icon icon="fullscreen" size={14} />
-				</a>
-			</div>
+			<HomeGlobe
+				channels={globeChannels}
+				zoom={1.5}
+				overlayHref={resolve('/channels/all') + '?display=map'}
+				compact
+				onvisible={() => (homeMapVisible = true)}
+			/>
 		</section>
 	{/if}
 </div>
@@ -675,13 +509,14 @@
 		margin-bottom: 0;
 	}
 
-	.homepage > .section:not(.section--globe) {
+	/* :global() on .section — it's also rendered by FeaturedChannels, which doesn't share this scope */
+	.homepage > :global(.section):not(.section--globe) {
 		position: relative;
 		z-index: 6;
 		background: var(--color-interface);
 	}
 
-	.homepage.signed-in > .section:not(.section--globe):not(.dashboard-section) {
+	.homepage.signed-in > :global(.section):not(.section--globe):not(.dashboard-section) {
 		position: relative;
 		z-index: 6;
 		background: var(--color-interface);
@@ -747,17 +582,6 @@
 		gap: 0.5rem;
 	}
 
-	.section--featured-col {
-		display: flex;
-		flex-direction: column;
-		justify-content: flex-start;
-	}
-
-	.section--globe--loggedout .globe {
-		max-height: 55dvh;
-		z-index: 0;
-	}
-
 	.loggedout-grid {
 		display: grid;
 		grid-template-columns: 1fr;
@@ -766,7 +590,8 @@
 		min-height: 0;
 		overflow: hidden;
 
-		& > section {
+		/* :global() — the section here comes from FeaturedChannels, not this scope */
+		& > :global(section) {
 			min-width: 0;
 			overflow: hidden;
 		}
@@ -905,16 +730,6 @@
 		line-height: 1;
 	}
 
-	.section-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-
-		.section-title {
-			margin-bottom: 0;
-		}
-	}
-
 	.section-title {
 		font-size: var(--font-7);
 		font-weight: 600;
@@ -945,114 +760,6 @@
 		max-width: none;
 		margin-inline: 0;
 		padding-inline: 0.5rem;
-	}
-
-	.globe {
-		position: relative;
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		min-height: 50dvh;
-		margin-top: -0.75rem;
-		background: transparent;
-		border-radius: var(--border-radius);
-		overflow: hidden;
-		:global(.map) {
-			flex: 1;
-			min-height: 0;
-		}
-		:global(article .description) {
-			display: none;
-		}
-	}
-
-	.globe-placeholder {
-		flex: 1;
-		min-height: 50dvh;
-		background:
-			radial-gradient(circle at 50% 42%, rgb(105 160 255 / 0.22), transparent 18%),
-			radial-gradient(circle at 50% 50%, rgb(36 72 126 / 0.85), rgb(9 15 24 / 0.95) 72%);
-	}
-
-	.map-overlay-btn {
-		position: absolute;
-		bottom: 0.5rem;
-		left: 0.5rem;
-		z-index: 10;
-		opacity: 0.7;
-		&:hover {
-			opacity: 1;
-		}
-	}
-
-	/* Featured loading skeleton — mirrors ChannelCard's structure so the slot height
-	   matches the real cards and nothing shifts when they load. */
-	.skeleton-card {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-		padding: var(--space-1);
-		height: 100%;
-	}
-
-	.sk-figure {
-		aspect-ratio: 1;
-		width: 100%;
-		border-radius: var(--border-radius);
-		background: var(--gray-2);
-	}
-
-	.sk-body {
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-		margin-top: 0.5rem;
-		flex: 1;
-	}
-
-	.sk-line {
-		background: var(--gray-2);
-		border-radius: 4px;
-	}
-
-	.sk-title {
-		height: 1rem;
-		width: 70%;
-	}
-
-	.sk-slug {
-		height: 0.5rem;
-		width: 40%;
-	}
-
-	.sk-desc {
-		height: 0.5rem;
-		width: 92%;
-		margin-top: 0.5rem;
-	}
-
-	.sk-desc--short {
-		width: 60%;
-		margin-top: 0;
-	}
-
-	.sk-meta {
-		height: 0.5rem;
-		width: 30%;
-		margin-top: auto;
-	}
-
-	@media (prefers-reduced-motion: no-preference) {
-		.skeleton-card .sk-figure,
-		.skeleton-card .sk-line {
-			animation: sk-pulse 1.4s ease-in-out infinite;
-		}
-	}
-
-	@keyframes sk-pulse {
-		50% {
-			opacity: 0.55;
-		}
 	}
 
 	.dismissible {

--- a/src/routes/[slug]/backup/+page.svelte
+++ b/src/routes/[slug]/backup/+page.svelte
@@ -6,6 +6,7 @@
 	import {getChannelCtx} from '$lib/contexts'
 	import Icon from '$lib/components/icon.svelte'
 	import ChannelNavControlsPortal from '$lib/components/channel-nav-controls-portal.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const channelCtx = getChannelCtx()
@@ -52,9 +53,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.channel_backup_page_title({handle: `@${slug}`})}</title>
-</svelte:head>
+<Seo title={m.channel_backup_page_title({handle: `@${slug}`})} plain />
 
 <ChannelNavControlsPortal controls={navControls} />
 

--- a/src/routes/[slug]/batch-edit/+page.svelte
+++ b/src/routes/[slug]/batch-edit/+page.svelte
@@ -14,6 +14,7 @@
 	import PopoverMenu from '$lib/components/popover-menu.svelte'
 	import ChannelNavControlsPortal from '$lib/components/channel-nav-controls-portal.svelte'
 	import Icon from '$lib/components/icon.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let slug = $derived(page.params.slug)
@@ -310,9 +311,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.batch_edit_page_title({name: channel?.name || m.channel_page_fallback()})}</title>
-</svelte:head>
+<Seo title={m.batch_edit_page_title({name: channel?.name || m.channel_page_fallback()})} plain />
 
 <ChannelNavControlsPortal controls={navControls} />
 

--- a/src/routes/[slug]/delete/+page.svelte
+++ b/src/routes/[slug]/delete/+page.svelte
@@ -8,6 +8,7 @@
 	import {channelsCollection} from '$lib/collections/channels'
 	import {tracksCollection} from '$lib/collections/tracks'
 	import {queryClient} from '$lib/collections/query-client'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const channelCtx = getChannelCtx()
@@ -76,9 +77,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.channel_delete_page_title({name: channel?.name || m.channel_page_fallback()})}</title>
-</svelte:head>
+<Seo title={m.channel_delete_page_title({name: channel?.name || m.channel_page_fallback()})} plain />
 
 <article>
 	{#if canDelete && channel}

--- a/src/routes/[slug]/edit/+page.svelte
+++ b/src/routes/[slug]/edit/+page.svelte
@@ -6,6 +6,7 @@
 	import {updateChannel} from '$lib/collections/channels'
 	import MapPicker from '$lib/components/map-picker.svelte'
 	import R4AvatarUpload from '$lib/components/r4-avatar-upload.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const channelCtx = getChannelCtx()
@@ -92,9 +93,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.channel_edit_page_title({name: channel?.name || m.channel_page_fallback()})}</title>
-</svelte:head>
+<Seo title={m.channel_edit_page_title({name: channel?.name || m.channel_page_fallback()})} plain />
 
 <article>
 	{#if canEdit && channel}

--- a/src/routes/[slug]/followers/+page.svelte
+++ b/src/routes/[slug]/followers/+page.svelte
@@ -12,6 +12,7 @@
 	import SearchInput from '$lib/components/search-input.svelte'
 	import Subpage from '$lib/components/subpage.svelte'
 	import ChannelNavControlsPortal from '$lib/components/channel-nav-controls-portal.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const d = appState.channels_display
@@ -99,9 +100,7 @@
 	{/if}
 {/snippet}
 
-<svelte:head>
-	<title>{m.nav_followers()} - {channel?.name || m.channel_page_fallback()}</title>
-</svelte:head>
+<Seo title={`${m.nav_followers()} - ${channel?.name || m.channel_page_fallback()}`} plain />
 
 <article class="channels-page fill-height">
 	<Subpage

--- a/src/routes/[slug]/followers/in-common/+page.svelte
+++ b/src/routes/[slug]/followers/in-common/+page.svelte
@@ -13,6 +13,7 @@
 	import SearchInput from '$lib/components/search-input.svelte'
 	import Subpage from '$lib/components/subpage.svelte'
 	import ChannelNavControlsPortal from '$lib/components/channel-nav-controls-portal.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const d = appState.channels_display
@@ -103,9 +104,7 @@
 	{/if}
 {/snippet}
 
-<svelte:head>
-	<title>{m.nav_in_common()} - {channel?.name || m.channel_page_fallback()}</title>
-</svelte:head>
+<Seo title={`${m.nav_in_common()} - ${channel?.name || m.channel_page_fallback()}`} plain />
 
 <article class="channels-page fill-height">
 	<Subpage

--- a/src/routes/[slug]/following/+page.svelte
+++ b/src/routes/[slug]/following/+page.svelte
@@ -14,6 +14,7 @@
 	import SearchInput from '$lib/components/search-input.svelte'
 	import Subpage from '$lib/components/subpage.svelte'
 	import ChannelNavControlsPortal from '$lib/components/channel-nav-controls-portal.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const FEATURED_LIMIT = 10
@@ -162,9 +163,7 @@
 	<ChannelsViewControls bind:display bind:order bind:direction />
 {/snippet}
 
-<svelte:head>
-	<title>{m.nav_following()} - {channel?.name || m.channel_page_fallback()}</title>
-</svelte:head>
+<Seo title={`${m.nav_following()} - ${channel?.name || m.channel_page_fallback()}`} plain />
 
 <article class="channels-page fill-height">
 	<Subpage

--- a/src/routes/[slug]/following/featured/+page.svelte
+++ b/src/routes/[slug]/following/featured/+page.svelte
@@ -14,6 +14,7 @@
 	import SearchInput from '$lib/components/search-input.svelte'
 	import Subpage from '$lib/components/subpage.svelte'
 	import ChannelNavControlsPortal from '$lib/components/channel-nav-controls-portal.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const FEATURED_LIMIT = 10
@@ -172,9 +173,7 @@
 	<ChannelsViewControls bind:display bind:order bind:direction />
 {/snippet}
 
-<svelte:head>
-	<title>{m.channel_section_featured_channels()} - {channel?.name || m.channel_page_fallback()}</title>
-</svelte:head>
+<Seo title={`${m.channel_section_featured_channels()} - ${channel?.name || m.channel_page_fallback()}`} plain />
 
 <article class="channels-page fill-height">
 	<Subpage

--- a/src/routes/[slug]/following/in-common/+page.svelte
+++ b/src/routes/[slug]/following/in-common/+page.svelte
@@ -14,6 +14,7 @@
 	import SearchInput from '$lib/components/search-input.svelte'
 	import Subpage from '$lib/components/subpage.svelte'
 	import ChannelNavControlsPortal from '$lib/components/channel-nav-controls-portal.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const FEATURED_LIMIT = 10
@@ -167,9 +168,7 @@
 	<ChannelsViewControls bind:display bind:order bind:direction />
 {/snippet}
 
-<svelte:head>
-	<title>{m.nav_in_common()} - {channel?.name || m.channel_page_fallback()}</title>
-</svelte:head>
+<Seo title={`${m.nav_in_common()} - ${channel?.name || m.channel_page_fallback()}`} plain />
 
 <article class="channels-page fill-height">
 	<Subpage

--- a/src/routes/[slug]/mentions/+page.svelte
+++ b/src/routes/[slug]/mentions/+page.svelte
@@ -10,6 +10,7 @@
 	import Subpage from '$lib/components/subpage.svelte'
 	import ChannelNavControlsPortal from '$lib/components/channel-nav-controls-portal.svelte'
 	import Icon from '$lib/components/icon.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import type {Track} from '$lib/types'
 	import * as m from '$lib/paraglide/messages'
 
@@ -89,9 +90,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.mentions_title({handle: `@${slug}`})}</title>
-</svelte:head>
+<Seo title={m.mentions_title({handle: `@${slug}`})} plain />
 
 <ChannelNavControlsPortal controls={navControls} />
 

--- a/src/routes/[slug]/trackids/+page.svelte
+++ b/src/routes/[slug]/trackids/+page.svelte
@@ -4,6 +4,7 @@
 	import {eq} from '@tanstack/db'
 	import {channelsCollection} from '$lib/collections/channels'
 	import {tracksCollection} from '$lib/collections/tracks'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const channelQuery = useLiveQuery((q) =>
@@ -21,9 +22,7 @@
 	const trackUrls = $derived(tracksQuery.data?.map((t) => t.url) || [])
 </script>
 
-<svelte:head>
-	<title>{m.track_urls_page_title({name: channel?.name || m.channel_page_fallback()})}</title>
-</svelte:head>
+<Seo title={m.track_urls_page_title({name: channel?.name || m.channel_page_fallback()})} plain />
 
 {#if tracksQuery.isLoading}
 	<p>{m.common_loading()}</p>

--- a/src/routes/[slug]/tracks/[tid]/delete/+page.svelte
+++ b/src/routes/[slug]/tracks/[tid]/delete/+page.svelte
@@ -6,6 +6,7 @@
 	import {appState, canEditChannel} from '$lib/app-state.svelte'
 	import {tracksCollection, deleteTrack} from '$lib/collections/tracks'
 	import {channelsCollection} from '$lib/collections/channels'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let {data} = $props()
@@ -54,9 +55,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.common_delete()} {track?.title || m.track_page_fallback()}</title>
-</svelte:head>
+<Seo title={`${m.common_delete()} ${track?.title || m.track_page_fallback()}`} plain />
 
 <article class="constrained focused">
 	{#if isLoading}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -7,6 +7,7 @@
 	import ChannelCard from '$lib/components/channel-card.svelte'
 	import * as m from '$lib/paraglide/messages'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 
 	const FEATURED_DAYS = 30
 
@@ -27,9 +28,7 @@
 	})
 </script>
 
-<svelte:head>
-	<title>{m.about_title({appName})}</title>
-</svelte:head>
+<Seo title={m.about_title({appName})} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/about/economy/+page.svelte
+++ b/src/routes/about/economy/+page.svelte
@@ -8,6 +8,7 @@
 	import BackLink from '$lib/components/back-link.svelte'
 	import InputRange from '$lib/components/input-range.svelte'
 	import SearchInput from '$lib/components/search-input.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import {
 		computeEconomy,
 		computeChannelEconomy,
@@ -139,9 +140,7 @@
 	)
 </script>
 
-<svelte:head>
-	<title>Economy — {appName}</title>
-</svelte:head>
+<Seo title={`Economy — ${appName}`} plain />
 
 <div class="economy fill-height">
 	<!-- ═══ SIDEBAR ═══ -->

--- a/src/routes/add/+page.svelte
+++ b/src/routes/add/+page.svelte
@@ -4,6 +4,7 @@
 	import {page} from '$app/state'
 	import {appState} from '$lib/app-state.svelte'
 	import TrackForm from '$lib/components/track-form.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const rawUrl = $derived(page?.url?.searchParams?.get('url') || '')
@@ -30,9 +31,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.page_title_add_track()}</title>
-</svelte:head>
+<Seo title={m.page_title_add_track()} plain />
 
 <article class="constrained">
 	{#if canAddTrack && channel}

--- a/src/routes/apps/+page.svelte
+++ b/src/routes/apps/+page.svelte
@@ -4,14 +4,13 @@
 	import * as m from '$lib/paraglide/messages'
 	import BackLink from '$lib/components/back-link.svelte'
 	import Icon from '$lib/components/icon.svelte'
+	import Seo from '$lib/components/seo.svelte'
 
 	const blogPostUrl =
 		'https://blog.radio4000.com/posts/use-radio4000-on-mobile-android-firefox-and-lock-the-screen/'
 </script>
 
-<svelte:head>
-	<title>{m.apps_title()} — {appName}</title>
-</svelte:head>
+<Seo title={`${m.apps_title()} — ${appName}`} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -6,6 +6,7 @@
 	import {appState} from '$lib/app-state.svelte'
 	import ChannelCard from '$lib/components/channel-card.svelte'
 	import IconR4 from '$lib/components/icon-r4.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import {useLiveQuery} from '$lib/useLiveQuery.svelte'
 	import {inArray} from '@tanstack/db'
 	import {channelsCollection} from '$lib/collections/channels'
@@ -39,9 +40,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.auth_page_title()}</title>
-</svelte:head>
+<Seo title={m.auth_page_title()} plain />
 
 <article class="constrained focused splash">
 	<figure class="logo">

--- a/src/routes/auth/create-account/+page.svelte
+++ b/src/routes/auth/create-account/+page.svelte
@@ -6,6 +6,7 @@
 	import * as m from '$lib/paraglide/messages'
 	import AuthSignup from '$lib/components/auth-signup.svelte'
 	import IconR4 from '$lib/components/icon-r4.svelte'
+	import Seo from '$lib/components/seo.svelte'
 
 	const redirect = $derived(page.url.searchParams.get('redirect') || '/settings')
 
@@ -16,9 +17,7 @@
 	const isCheckEmail = $derived(step === 'linkSent' || step === 'confirmEmail')
 </script>
 
-<svelte:head>
-	<title>{m.auth_create_page_title()}</title>
-</svelte:head>
+<Seo title={m.auth_create_page_title()} plain />
 
 <article class="constrained constrained--smaller focused splash">
 	<figure class="logo">

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -6,6 +6,7 @@
 	import * as m from '$lib/paraglide/messages'
 	import AuthLogin from '$lib/components/auth-login.svelte'
 	import IconR4 from '$lib/components/icon-r4.svelte'
+	import Seo from '$lib/components/seo.svelte'
 
 	const redirect = $derived(page.url.searchParams.get('redirect') || '/settings')
 	let step = $state('providers')
@@ -16,9 +17,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.auth_login_page_title()}</title>
-</svelte:head>
+<Seo title={m.auth_login_page_title()} plain />
 
 <article class="constrained focused splash">
 	<figure class="logo">

--- a/src/routes/auth/reset-password/+page.svelte
+++ b/src/routes/auth/reset-password/+page.svelte
@@ -4,6 +4,7 @@
 	import {resolve} from '$app/paths'
 	import {appChatUrl} from '$lib/config'
 	import IconR4 from '$lib/components/icon-r4.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const log = logger.ns('auth').seal()
@@ -36,9 +37,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.auth_reset_page_title()}</title>
-</svelte:head>
+<Seo title={m.auth_reset_page_title()} plain />
 
 <article class="constrained focused splash">
 	<figure class="logo">

--- a/src/routes/auth/reset-password/confirm/+page.svelte
+++ b/src/routes/auth/reset-password/confirm/+page.svelte
@@ -2,6 +2,7 @@
 	import {resolve} from '$app/paths'
 	import {sdk} from '@radio4000/sdk'
 	import IconR4 from '$lib/components/icon-r4.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let password = $state('')
@@ -36,9 +37,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.auth_set_new_password()}</title>
-</svelte:head>
+<Seo title={m.auth_set_new_password()} plain />
 
 <article class="constrained focused splash">
 	<figure class="logo">

--- a/src/routes/bookmarklet/+page.svelte
+++ b/src/routes/bookmarklet/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import {appName} from '$lib/config'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const {data} = $props()
@@ -8,9 +9,7 @@
 	)
 </script>
 
-<svelte:head>
-	<title>{m.bookmarklet_title({appName})}</title>
-</svelte:head>
+<Seo title={m.bookmarklet_title({appName})} plain />
 
 <article class="constrained">
 	<h1>{m.bookmarklet_heading()}</h1>

--- a/src/routes/broadcast/+page.svelte
+++ b/src/routes/broadcast/+page.svelte
@@ -3,6 +3,7 @@
 	import {appState} from '$lib/app-state.svelte'
 	import Icon from '$lib/components/icon.svelte'
 	import IconR4 from '$lib/components/icon-r4.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const userChannel = $derived(appState.channel)
@@ -12,9 +13,7 @@
 	)
 </script>
 
-<svelte:head>
-	<title>{m.broadcasts_you_are_live()}</title>
-</svelte:head>
+<Seo title={m.broadcasts_you_are_live()} plain />
 
 <div class="broadcast-page">
 	<div class="broadcast-bar">

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -1,10 +1,9 @@
 <script>
 	import LiveChat from '$lib/components/live-chat.svelte'
+	import Seo from '$lib/components/seo.svelte'
 </script>
 
-<svelte:head>
-	<title>Chat</title>
-</svelte:head>
+<Seo title="Chat" plain />
 
 <div class="constrained container">
 	<LiveChat />

--- a/src/routes/explore/channels/[filter]/+page.svelte
+++ b/src/routes/explore/channels/[filter]/+page.svelte
@@ -1,13 +1,12 @@
 <script>
 	import {appName} from '$lib/config'
 	import Channels from '$lib/components/channels.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const {data} = $props()
 </script>
 
-<svelte:head>
-	<title>{m.explore_title({appName})}</title>
-</svelte:head>
+<Seo title={m.explore_title({appName})} plain />
 
 <Channels filter={data.filter} filterBasePath="/explore/channels" searchHref="/search/channels" />

--- a/src/routes/explore/tags/[filter]/+page.svelte
+++ b/src/routes/explore/tags/[filter]/+page.svelte
@@ -10,6 +10,7 @@
 	import SearchInput from '$lib/components/search-input.svelte'
 	import ExplorePageHeader from '$lib/components/explore-page-header.svelte'
 	import TagRow from '$lib/components/tag-row.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import {tooltip} from '$lib/components/tooltip-attachment.svelte.js'
 	import * as m from '$lib/paraglide/messages'
 
@@ -54,9 +55,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.explore_title({appName})}</title>
-</svelte:head>
+<Seo title={m.explore_title({appName})} plain />
 
 <div class="layout">
 	<ExplorePageHeader>

--- a/src/routes/explore/tracks/[filter]/+page.svelte
+++ b/src/routes/explore/tracks/[filter]/+page.svelte
@@ -10,6 +10,7 @@
 	import ChannelMicroCard from '$lib/components/channel-micro-card.svelte'
 	import ExplorePageHeader from '$lib/components/explore-page-header.svelte'
 	import SearchInput from '$lib/components/search-input.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const {data} = $props()
@@ -89,9 +90,7 @@
 	const groupedTracks = $derived(groupByDay(tracks))
 </script>
 
-<svelte:head>
-	<title>{m.explore_title({appName})}</title>
-</svelte:head>
+<Seo title={m.explore_title({appName})} plain />
 
 <div class="layout">
 	<ExplorePageHeader>

--- a/src/routes/explore/tracks/network/+page.svelte
+++ b/src/routes/explore/tracks/network/+page.svelte
@@ -10,6 +10,7 @@
 	import ChannelMicroCard from '$lib/components/channel-micro-card.svelte'
 	import ExplorePageHeader from '$lib/components/explore-page-header.svelte'
 	import SearchInput from '$lib/components/search-input.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let search = $state('')
@@ -53,9 +54,7 @@
 	})
 </script>
 
-<svelte:head>
-	<title>{m.nav_feed()} — {appName}</title>
-</svelte:head>
+<Seo title={`${m.nav_feed()} — ${appName}`} plain />
 
 <div class="feed">
 	<ExplorePageHeader>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -16,6 +16,7 @@
 	import ChannelMicroCard from '$lib/components/channel-micro-card.svelte'
 	import DateTime from '$lib/components/date-time.svelte'
 	import Icon from '$lib/components/icon.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import type {Track, PlayStartReason} from '$lib/types'
 	import {parseUrl} from 'media-now'
 
@@ -113,9 +114,7 @@
 	const locale = $derived(appState.language || getLocale())
 </script>
 
-<svelte:head>
-	<title>{m.page_title_history()}</title>
-</svelte:head>
+<Seo title={m.page_title_history()} plain />
 
 <article class="">
 	<header class="constrained">

--- a/src/routes/history/stats/+page.svelte
+++ b/src/routes/history/stats/+page.svelte
@@ -9,6 +9,7 @@
 	import {followsCollection} from '$lib/collections/follows'
 	import {queryClient} from '$lib/collections/query-client'
 	import {useLiveQuery} from '$lib/useLiveQuery.svelte'
+	import Seo from '$lib/components/seo.svelte'
 
 	// Reactive reads — updates live as you play tracks, follow channels, etc.
 	const eventsQuery = useLiveQuery((q) => q.from({ev: captureEventsCollection}))
@@ -236,9 +237,7 @@
 	})
 </script>
 
-<svelte:head>
-	<title>{m.page_title_stats()}</title>
-</svelte:head>
+<Seo title={m.page_title_stats()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/menu/+page.svelte
+++ b/src/routes/menu/+page.svelte
@@ -10,6 +10,7 @@
 	import {repoBlobUrl, repoUrl, repoCommitUrl} from '$lib/repo'
 	import BackLink from '$lib/components/back-link.svelte'
 	import LanguageSwitcher from '$lib/components/language-switcher.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import {appPresence} from '$lib/presence.svelte.js'
 
 	const sha = __GIT_INFO__.sha
@@ -37,9 +38,7 @@
 	})
 </script>
 
-<svelte:head>
-	<title>Menu — {appName}</title>
-</svelte:head>
+<Seo title={`Menu — ${appName}`} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/menu/community/+page.svelte
+++ b/src/routes/menu/community/+page.svelte
@@ -3,11 +3,10 @@
 	import {appName, communityLinks, appContactEmail} from '$lib/config'
 	import BackLink from '$lib/components/back-link.svelte'
 	import Icon from '$lib/components/icon.svelte'
+	import Seo from '$lib/components/seo.svelte'
 </script>
 
-<svelte:head>
-	<title>Community — {appName}</title>
-</svelte:head>
+<Seo title={`Community — ${appName}`} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -13,6 +13,7 @@
 	import SearchTrackMenu from '$lib/components/search-track-menu.svelte'
 	import {searchChannelsCombined} from '$lib/search'
 	import Pagination from '$lib/components/pagination.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import {channelsCollection} from '$lib/collections/channels'
 	import {tracksCollection} from '$lib/collections/tracks'
 	import {featuredScore, getTopTagValues, seededRandom, shuffleArray, shuffleSeed} from '$lib/utils'
@@ -106,9 +107,7 @@
 	})
 </script>
 
-<svelte:head>
-	<title>{m.search_title()}</title>
-</svelte:head>
+<Seo title={m.search_title()} plain />
 
 <article {@attach fromAction(trap)}>
 	<SearchShell

--- a/src/routes/search/channels/+page.svelte
+++ b/src/routes/search/channels/+page.svelte
@@ -8,6 +8,7 @@
 	import {getTopChannelSlugs} from '$lib/utils'
 	import ChannelCard from '$lib/components/channel-card.svelte'
 	import SearchShell from '$lib/components/search-shell.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import {trap} from '$lib/focus'
 	import {fromAction} from 'svelte/attachments'
 	import * as m from '$lib/paraglide/messages'
@@ -52,9 +53,7 @@
 	})
 </script>
 
-<svelte:head>
-	<title>{m.search_title()}</title>
-</svelte:head>
+<Seo title={m.search_title()} plain />
 
 <article {@attach fromAction(trap)}>
 	<SearchShell {uid} bind:value={search.value} onsubmit={search.handleSubmit} />

--- a/src/routes/search/tracks/+page.svelte
+++ b/src/routes/search/tracks/+page.svelte
@@ -16,6 +16,7 @@
 	import {trap} from '$lib/focus'
 	import {fromAction} from 'svelte/attachments'
 	import Pagination from '$lib/components/pagination.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import {getTopChannelSlugs, getTopTagValues} from '$lib/utils'
 	import * as m from '$lib/paraglide/messages'
 
@@ -44,9 +45,7 @@
 	const featuredTags = $derived(getTopTagValues([...tracksCollection.state.values()], 12))
 </script>
 
-<svelte:head>
-	<title>{m.search_title()}</title>
-</svelte:head>
+<Seo title={m.search_title()} plain />
 
 <article {@attach fromAction(trap)}>
 	<SearchShell

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -3,11 +3,10 @@
 	import * as m from '$lib/paraglide/messages'
 	import Icon from '$lib/components/icon.svelte'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 </script>
 
-<svelte:head>
-	<title>{m.settings_title()}</title>
-</svelte:head>
+<Seo title={m.settings_title()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/account/+page.svelte
+++ b/src/routes/settings/account/+page.svelte
@@ -4,6 +4,7 @@
 	import {appState} from '$lib/app-state.svelte'
 	import {appName} from '$lib/config'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let providerLoading = $state(/** @type {string | null} */ (null))
@@ -63,9 +64,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.settings_account()}</title>
-</svelte:head>
+<Seo title={m.settings_account()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/account/delete/+page.svelte
+++ b/src/routes/settings/account/delete/+page.svelte
@@ -4,6 +4,7 @@
 	import {resolve} from '$app/paths'
 	import {appState} from '$lib/app-state.svelte'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let confirmDelete = $state(false)
@@ -24,9 +25,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.account_delete_title()}</title>
-</svelte:head>
+<Seo title={m.account_delete_title()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/account/email/+page.svelte
+++ b/src/routes/settings/account/email/+page.svelte
@@ -4,6 +4,7 @@
 	import {sdk} from '@radio4000/sdk'
 	import {appState} from '$lib/app-state.svelte'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let newEmail = $state('')
@@ -36,9 +37,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.account_change_email()}</title>
-</svelte:head>
+<Seo title={m.account_change_email()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/account/password/+page.svelte
+++ b/src/routes/settings/account/password/+page.svelte
@@ -3,6 +3,7 @@
 	import {sdk} from '@radio4000/sdk'
 	import {appState} from '$lib/app-state.svelte'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let newPassword = $state('')
@@ -40,9 +41,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.account_change_password()}</title>
-</svelte:head>
+<Seo title={m.account_change_password()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/analytics/+page.svelte
+++ b/src/routes/settings/analytics/+page.svelte
@@ -3,6 +3,7 @@
 	import {resolve} from '$app/paths'
 	import {appName} from '$lib/config'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 	import {repoCodeSearchUrl, repoUrl, supportsCodeSearch} from '$lib/repo'
 
@@ -10,9 +11,7 @@
 	const analyticsCaptureSearchUrl = repoCodeSearchUrl('"capture(" path:src')
 </script>
 
-<svelte:head>
-	<title>{m.settings_analytics_title()} — {m.settings_title()}</title>
-</svelte:head>
+<Seo title={`${m.settings_analytics_title()} — ${m.settings_title()}`} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/appearance/+page.svelte
+++ b/src/routes/settings/appearance/+page.svelte
@@ -2,12 +2,11 @@
 	import ThemeEditor from '$lib/components/theme-editor.svelte'
 	import {resolve} from '$app/paths'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 </script>
 
-<svelte:head>
-	<title>{m.settings_appearance_title()}</title>
-</svelte:head>
+<Seo title={m.settings_appearance_title()} plain />
 
 <article>
 	<div class="focused constrained">

--- a/src/routes/settings/import/+page.svelte
+++ b/src/routes/settings/import/+page.svelte
@@ -3,14 +3,13 @@
 	import {resolve} from '$app/paths'
 	import BackLink from '$lib/components/back-link.svelte'
 	import Icon from '$lib/components/icon.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const importedCount = $derived(appState.local_channels?.length ?? 0)
 </script>
 
-<svelte:head>
-	<title>{m.import_title()}</title>
-</svelte:head>
+<Seo title={m.import_title()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/import/backup/+page.svelte
+++ b/src/routes/settings/import/backup/+page.svelte
@@ -4,6 +4,7 @@
 	import type {ImportResult} from '$lib/import'
 	import BackLink from '$lib/components/back-link.svelte'
 	import Dropzone from '$lib/components/dropzone.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let error = $state('')
@@ -48,9 +49,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.import_backup_title()}</title>
-</svelte:head>
+<Seo title={m.import_backup_title()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/import/folder/+page.svelte
+++ b/src/routes/settings/import/folder/+page.svelte
@@ -16,6 +16,7 @@
 	} from '$lib/import'
 	import BackLink from '$lib/components/back-link.svelte'
 	import Dropzone from '$lib/components/dropzone.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 	import type {Channel, Track, ImportOrigin} from '$lib/types'
 
@@ -316,9 +317,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.import_folder_title()}</title>
-</svelte:head>
+<Seo title={m.import_folder_title()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/import/m3u/+page.svelte
+++ b/src/routes/settings/import/m3u/+page.svelte
@@ -6,6 +6,7 @@
 	import type {ImportResult} from '$lib/import'
 	import BackLink from '$lib/components/back-link.svelte'
 	import Dropzone from '$lib/components/dropzone.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	let error = $state('')
@@ -55,9 +56,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.import_m3u_title()}</title>
-</svelte:head>
+<Seo title={m.import_m3u_title()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/keyboard/+page.svelte
+++ b/src/routes/settings/keyboard/+page.svelte
@@ -2,12 +2,11 @@
 	import KeyboardEditor from '$lib/components/keyboard-editor.svelte'
 	import {resolve} from '$app/paths'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 </script>
 
-<svelte:head>
-	<title>{m.page_title_keyboard()}</title>
-</svelte:head>
+<Seo title={m.page_title_keyboard()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/pins/+page.svelte
+++ b/src/routes/settings/pins/+page.svelte
@@ -11,6 +11,7 @@
 	import {resolve} from '$app/paths'
 	import BackLink from '$lib/components/back-link.svelte'
 	import Icon from '$lib/components/icon.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 
 	const viewsQuery = useLiveQuery(viewsCollection)
@@ -54,9 +55,7 @@
 	}
 </script>
 
-<svelte:head>
-	<title>{m.views_pins_title()}</title>
-</svelte:head>
+<Seo title={m.views_pins_title()} plain />
 
 <article class="focused constrained">
 	<header>

--- a/src/routes/settings/player/+page.svelte
+++ b/src/routes/settings/player/+page.svelte
@@ -2,12 +2,11 @@
 	import {appState} from '$lib/app-state.svelte'
 	import {resolve} from '$app/paths'
 	import BackLink from '$lib/components/back-link.svelte'
+	import Seo from '$lib/components/seo.svelte'
 	import * as m from '$lib/paraglide/messages'
 </script>
 
-<svelte:head>
-	<title>{m.settings_player()} — {m.settings_title()}</title>
-</svelte:head>
+<Seo title={`${m.settings_player()} — ${m.settings_title()}`} plain />
 
 <article class="focused constrained">
 	<header>


### PR DESCRIPTION
Two related cleanups that share src/routes/+page.svelte:

**Seo everywhere** — refactor 50 routes off raw `<svelte:head>`, and re-use our own `seo.svelte` component.

**Homepage** — the twice-pasted featured-channels section (with its CLS skeleton) and the twice-pasted lazy-loading globe move into `featured-channels.svelte` and `home-globe.svelte`. +page.svelte goes 1140 → 848 lines. Fixed en route: three scoped CSS selectors that reached into now-child-component markup and would have silently stopped applying.

Also prunes the landed items from plan.md.

Tests 220 pass (+1 pre-existing expected fail), svelte-check 0 errors, lint clean.