### PR TITLE
Docs: reference.json upkeep note, verify commands, new API entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,15 @@ For any task or question:
 /src/lib/components   -- components
 ```
 
+Verify with `bun run test` (one known failing test is expected), `bun run types`, `bun run lint`.
+
 Be concise. Short answers, no walls of text.
 
 Name CSS classes by primitive/identity (`tabs`, `btn`, `chip`, `link`, etc.), not by location (`explore-section-menu`) — reusable vocabulary styled once in `src/styles/`.
 
 ## Key docs
 
-- [reference](docs/reference.json) - scan for relevant functions, SDK methods, components, types
+- [reference](docs/reference.json) - scan for relevant functions, SDK methods, components, types. Maintained by hand — update it when you add or change APIs (`sg-ast outline` helps list what's where)
 - [universe](docs/universe.md) - domain model: channels, tracks, views, decks, broadcast, auto-radio
 - [state](docs/state.md) - how data flows (remote, local sync, app state)
 - [tone](docs/tone.md) - voice and tone for all copy (UI, docs, changelog)

--- a/docs/reference.json
+++ b/docs/reference.json
@@ -584,7 +584,13 @@
 
 		{"name": "Channels", "desc": "Grid/list/map/tuner views with filter, sort, shuffle."},
 		{"name": "ChannelCard", "desc": "Channel preview with avatar, description, live dot."},
+		{
+			"name": "FeaturedChannels",
+			"desc": "Featured channels grid: seeded pick, reshuffle, play toggle."
+		},
+		{"name": "HomeGlobe", "desc": "Lazy channels globe — loads map when scrolled into view."},
 
+		{"name": "Seo", "desc": "Page title and meta/OG tags. plain prop skips the app-name suffix."},
 		{"name": "dialog.svelte", "desc": "Generic dialog wrapper with header/children snippets."},
 		{"name": "date-formal.svelte", "desc": "Localized formal date-time display."},
 		{"name": "Icon", "desc": "Iconify icon wrapper."},
@@ -613,6 +619,18 @@
 			"name": "unpackEphemeralTrack(track_id, payload)",
 			"desc": "Reconstruct Track from broadcast payload."
 		}
+	],
+
+	"src/lib/player/broadcast-utils.js": [
+		{
+			"name": "pickBroadcastFields(source)",
+			"desc": "Pick shared playback fields off a Deck, Broadcast row or BroadcastDeckState."
+		},
+		{
+			"name": "composeBroadcastDeckState(index, trackId, deck, ephemeralPayload)",
+			"desc": "Compose one deck's outbound broadcast wire state."
+		},
+		{"name": "BROADCAST_STATE_DEFAULTS", "desc": "Defaults for the shared playback fields."}
 	],
 
 	"src/lib/player/deck-display.svelte.ts": [


### PR DESCRIPTION
Retro follow-ups from the seo/broadcast session:

- AGENTS.md: note that `docs/reference.json` is maintained by hand (update it when APIs change, `sg-ast outline` helps), plus a one-liner on how to verify (`bun run test` / `types` / `lint`, one known failing test is expected).
- reference.json: entries for `FeaturedChannels`, `HomeGlobe`, `Seo`, and the new `broadcast-utils.js` helpers. These document code landing in #181 and #182.