### PR TITLE
Pin deck queues by channel instead of by track id

### DIFF
--- a/docs/queue.md
+++ b/docs/queue.md
@@ -6,6 +6,6 @@ Queue state in `appState`: `playlist_tracks` (ordered IDs), `playlist_tracks_shu
 
 Pure functions in `$lib/player/queue.ts` operate on `string[]` of track IDs: `queueNext`, `queuePrev`, `queueInsertManyAfter`, `queueRemove`, `queueShuffleKeepCurrent`, `queueRotate`, `queueUnique`.
 
-The panel (`queue-panel.svelte`) queries `tracksCollection` with `inArray` for queued IDs, reorders to match playlist. Searchable via fuzzysort. Left edge draggable to resize (200–800px, disabled on mobile).
+The panel (`queue-panel.svelte`) resolves queued IDs against `tracksCollection` with Map lookups in playlist order — an `inArray` live query over a long queue blocks the main thread for seconds (see [tanstack](tanstack.md)). Searchable via fuzzysort. Left edge draggable to resize (200–800px, disabled on mobile).
 
 Play history lives at `/history`, powered by [capture events](play-history.md).

--- a/docs/tanstack.md
+++ b/docs/tanstack.md
@@ -67,6 +67,8 @@ For server-backed collections like `tracks` and `channels`, `onInsert` and `onUp
 
 Resolving specific ids (`ids.map((id) => collection.state.get(id))`) is O(1) per id. Expressing the same as a live query — `useLiveQuery((q) => q.from(...).where(inArray(id, ids)))` — builds a d2ts pipeline that rebuilds on every change; over a multi-thousand-row collection that is a ~1s main-thread block.
 
+Why: `in` scans the whole value list per row, so `inArray` filters are O(ids × rows) — seconds of main-thread blocking at a few thousand of each. Prefer a filter over a field with few distinct values (`eq(t.slug, slug)`) — one comparison per row. Related: `collection.state` is a getter that rebuilds a snapshot Map on every access — in loops, hoist it or use `collection.get(id)`, the direct O(1) lookup.
+
 Keep the Map lookups, but make them reactive by reading a **direct-collection** query as a trigger:
 
 ```js
@@ -140,6 +142,10 @@ Caveats learned the hard way:
 - `.offset()` is applied locally by d2ts, not forwarded to Supabase (the sync layer always fetches from row 0 with `limit = offset + pageSize`). Don't use it for server-side pagination.
 - For paged views, accumulate `limit = currentPage * pageSize` and `.slice()` locally. The `queryFn` should delta-fetch: look up cached results for the same query shape with a smaller limit and fetch only the new rows. See `channels.ts` `queryFn`.
 - Each dep change in `useLiveQuery` creates a new `createLiveQueryCollection`; our wrapper `cleanup()`s the old one to stop its d2ts pipeline and pending callbacks. Without this, stale collections cause delayed re-renders.
+
+### keepalive pin
+
+On-demand collections evict rows once no subscriber owns their subset — `tracks-keepalive.svelte` (with `collections/keepalive.ts`) pins a deck's queue resident; the how and why live in those files.
 
 ## debug routes
 

--- a/src/lib/collections/keepalive.test.ts
+++ b/src/lib/collections/keepalive.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from 'vitest'
+import {queuePinTargets} from './keepalive'
+
+describe('queuePinTargets', () => {
+	const lookup = (rows: Record<string, {slug?: string | null}>) => (id: string) => rows[id]
+
+	it('pins by slug when the view or loaded rows name the channels, ephemeral rows by id', () => {
+		const deck = {playlist_tracks: ['a', 'discogs-1'], playlist_slug: 'oskar', view: undefined}
+		expect(queuePinTargets(deck, lookup({a: {slug: 'oskar'}, 'discogs-1': {slug: null}}))).toEqual(
+			{slugs: ['oskar'], ids: ['discogs-1']}
+		)
+		const viewDeck = {
+			playlist_tracks: ['a'],
+			playlist_slug: undefined,
+			view: {sources: [{channels: ['ko002', 'nomads']}]}
+		}
+		expect(queuePinTargets(viewDeck, lookup({}))).toEqual({slugs: ['ko002', 'nomads'], ids: []})
+	})
+
+	it('falls back to id pinning when slugs cannot be trusted', () => {
+		// Half-loaded viewless queue: a slug pin derived from partial rows would evict the rest.
+		const deck = {playlist_tracks: ['a', 'b'], playlist_slug: 'oskar', view: undefined}
+		expect(queuePinTargets(deck, lookup({a: {slug: 'oskar'}}))).toEqual({slugs: [], ids: ['a', 'b']})
+		// Too many channels (search/tag queues): pinning them whole loads far more than the queue.
+		const ids = ['a', 'b', 'c', 'd', 'e']
+		const rows = Object.fromEntries(ids.map((id, i) => [id, {slug: `chan-${i}`}]))
+		const wideDeck = {playlist_tracks: ids, playlist_slug: undefined, view: undefined}
+		expect(queuePinTargets(wideDeck, lookup(rows))).toEqual({slugs: [], ids})
+	})
+})

--- a/src/lib/collections/keepalive.ts
+++ b/src/lib/collections/keepalive.ts
@@ -1,0 +1,62 @@
+/**
+ * What to pin so a deck's queue survives on-demand collection GC.
+ * Workaround for TanStack DB evaluating `inArray` as a full list scan per row —
+ * see tracks-keepalive.svelte and docs/tanstack.md.
+ */
+import type {Deck} from '$lib/types'
+
+/** Above this many channels a queue is a view (search, tags) rather than a channel,
+ *  and pinning whole channels would load far more than the queue needs. */
+const MAX_PINNED_CHANNELS = 4
+
+/**
+ * Channels first: few, cover the same rows, cheap to filter on, and stable while
+ * the deck plays them. `ids` is the fallback for rows no channel pin can reach:
+ * ephemeral Discogs tracks, queues spread over too many channels, and queues whose
+ * channels we can't yet name — all short, or rare, or both.
+ *
+ * A queue's channels are only trusted when the deck's view names them, or when every
+ * row is loaded and can say which channel it belongs to. Guessing from a half-loaded
+ * queue would shrink the pin, evict the rest, and shrink it again.
+ *
+ * Pass a snapshot read as getTrack (`collection.get`), deliberately non-reactive to
+ * row loads: a half-loaded queue stays on the id pin until the deck next churns.
+ * Over-pins, never under-pins — don't "fix" it into a live query.
+ */
+export function queuePinTargets(
+	deck: Pick<Deck, 'playlist_tracks' | 'playlist_slug' | 'view'> | undefined,
+	getTrack: (id: string) => {slug?: string | null} | undefined
+): {slugs: string[]; ids: string[]} {
+	if (!deck) return {slugs: [], ids: []}
+	const tracks = deck.playlist_tracks ?? []
+	const viewSlugs = new Set<string>()
+	for (const source of deck.view?.sources ?? []) {
+		for (const channel of source?.channels ?? []) viewSlugs.add(channel)
+	}
+	// The view declares where the queue comes from — the one channel list that stays
+	// true no matter what is loaded.
+	if (viewSlugs.size && viewSlugs.size <= MAX_PINNED_CHANNELS) {
+		const ids = tracks.filter((id) => {
+			const track = getTrack(id)
+			return track && !track.slug
+		})
+		return {slugs: [...viewSlugs].toSorted(), ids}
+	}
+
+	// No usable view (a track click rebuilds the queue and drops it): fall back to what the
+	// rows themselves say, but only while every one of them is there to say it.
+	const slugs = new Set<string>()
+	if (deck.playlist_slug) slugs.add(deck.playlist_slug)
+	const ids: string[] = []
+	let unresolved = 0
+	for (const id of tracks) {
+		const track = getTrack(id)
+		if (!track) unresolved++
+		else if (track.slug) slugs.add(track.slug)
+		else ids.push(id)
+	}
+	if (unresolved || !slugs.size || slugs.size > MAX_PINNED_CHANNELS) {
+		return {slugs: [], ids: [...tracks]}
+	}
+	return {slugs: [...slugs].toSorted(), ids}
+}

--- a/src/lib/components/tracks-keepalive.svelte
+++ b/src/lib/components/tracks-keepalive.svelte
@@ -1,18 +1,48 @@
 <script lang="ts">
-	import {inArray} from '@tanstack/db'
+	import {createLiveQueryCollection, eq, inArray} from '@tanstack/db'
 	import {tracksCollection} from '$lib/collections/tracks'
-	import {useLiveQuery} from '$lib/useLiveQuery.svelte'
+	import {logger} from '$lib/logger'
 
-	// Holds a deck's queue tracks resident in the on-demand collection for as long
-	// as this component is mounted, so navigating away doesn't GC the playing track
-	// (which nulls `provider` and tears down the media element — stopping playback).
-	// Pins by id, not slug, so multi-channel queues (views, search) stay covered.
-	// The caller keys this per deck, so one deck's queue changing never disturbs
-	// another's pin.
-	let {ids}: {ids: string[]} = $props()
+	const log = logger.ns('keepalive').seal()
 
-	useLiveQuery(
-		(q) => (ids.length ? q.from({t: tracksCollection}).where(({t}) => inArray(t.id, ids)) : null),
-		[() => ids.join(',')]
-	)
+	// Holds tracks resident in the on-demand collection while mounted — without a
+	// subscriber owning them, rows get evicted, which GCs the playing track and tears
+	// down the media element. Caller keys this per deck.
+	// A pin needs the subscription, never the rows — so it owns the live query
+	// directly; useLiveQuery would copy every matched row into component state on
+	// each change.
+	// `slugs` is the cheap pin (one comparison per row); `ids` is O(ids × rows) —
+	// pass only small sets. See queuePinTargets().
+	let {ids = [], slugs = []}: {ids?: string[]; slugs?: string[]} = $props()
+
+	const slugKey = $derived(slugs.join(','))
+	const idKey = $derived(ids.join(','))
+
+	/** Own a subset until the effect tears down. Ownership follows the subscription,
+	 *  not the query — an unsubscribed live query lets its rows get collected. */
+	function pin(query: Parameters<typeof createLiveQueryCollection>[0]['query']) {
+		const collection = createLiveQueryCollection({query, startSync: true})
+		const subscription = collection.subscribeChanges(() => {})
+		collection.preload().catch(log.error)
+		return () => {
+			subscription.unsubscribe()
+			collection.cleanup()
+		}
+	}
+
+	$effect(() => {
+		if (!slugKey) return
+		const list = slugKey.split(',')
+		return pin((q) =>
+			q
+				.from({t: tracksCollection})
+				.where(({t}) => (list.length === 1 ? eq(t.slug, list[0]) : inArray(t.slug, list)))
+		)
+	})
+
+	$effect(() => {
+		if (!idKey) return
+		const list = idKey.split(',')
+		return pin((q) => q.from({t: tracksCollection}).where(({t}) => inArray(t.id, list)))
+	})
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -36,6 +36,8 @@
 	import {leaveBroadcast, resyncBroadcastDeck} from '$lib/broadcast.js'
 	import {channelsCollection} from '$lib/collections/channels'
 	import TracksKeepalive from '$lib/components/tracks-keepalive.svelte'
+	import {tracksCollection} from '$lib/collections/tracks'
+	import {queuePinTargets} from '$lib/collections/keepalive'
 	import {channelPresence} from '$lib/presence.svelte'
 	import Icon from '$lib/components/icon.svelte'
 	import PresenceCount from '$lib/components/presence-count.svelte'
@@ -255,11 +257,13 @@
 			<ShortcutsDialog />
 
 			{#each allDeckIds as deckId (deckId)}
-				<!-- Two pins: the whole queue (for next/prev) and, separately, the current
-				     track. The queue pin re-hashes on queue edits and the current-track pin
-				     re-hashes on track changes — but never together, so one always keeps the
-				     playing row resident while the other swaps. -->
-				<TracksKeepalive ids={appState.decks[deckId]?.playlist_tracks ?? []} />
+				<!-- Two pins per deck — whole queue and current track — that never re-hash
+				     together, so one always keeps the playing row resident while the other
+				     swaps. The snapshot read (.get) is deliberate — see queuePinTargets(). -->
+				{@const queuePin = queuePinTargets(appState.decks[deckId], (id) =>
+					tracksCollection.get(id)
+				)}
+				<TracksKeepalive slugs={queuePin.slugs} ids={queuePin.ids} />
 				<TracksKeepalive
 					ids={appState.decks[deckId]?.playlist_track
 						? [appState.decks[deckId].playlist_track]


### PR DESCRIPTION
Switching between two channels froze the browser for seconds. In Firefox it was up to 15 seconds in a single frame.

It wasn't the player. Each deck kept its queue loaded with a live query `where(inArray(t.id, ids))`, and TanStack DB evaluates `in` by scanning the whole id list once per row in the collection. A 2500-track queue over 4000 loaded tracks is ~10 million comparisons, synchronously, every time you press play on another channel. Cost was a flat ~2ms per track in the queue.

Now the pin goes by channel slug instead — one comparison per row. `queuePinTargets()` works out which channels a queue covers: it trusts the deck's view when the view names channels, otherwise the rows themselves, but only while all of them are loaded (guessing from a half-loaded queue shrinks the pin, which evicts the rest, which shrinks it again). Queues spread over more than four channels — search and tag views, always short — still pin by id, so pinning never drags in whole channels the queue barely touches.

The pin also owns its live query directly instead of going through `useLiveQuery`, which was copying every matched row into component state on each change. A keepalive needs the subscription, never the rows. Worth knowing: ownership follows the subscription, not the query — an unsubscribed live query lets its rows get collected, which cost me a round of debugging.

One more thing fixed along the way: `collection.state` rebuilds a snapshot Map on every access, so `.state.get(id)` in a loop is quadratic. `collection.get(id)` is the O(1) one.

## Measured

Clicking channel avatars back and forth on `/search/channels?q=nomad`, decks muted:

| | before | after |
|---|---|---|
| Chromium, main thread blocked per switch | 1968–3228 ms | 95–150 ms |
| Chromium, cold (first play, incl. fetch) | 2995–4021 ms | 135–206 ms |
| Firefox, worst frozen frame | 6233–14900 ms | 0–317 ms |
| Firefox, click to deck holding the channel | often never within 8s | 200–490 ms |

## Checked

Play/pause, next/prev, auto-radio, multi-channel "Play all". Navigating away while playing keeps the queue resident — the playing channel's rows stay, the other channel's are collected, and a 50-track search queue keeps all 50. No console errors. 11 tests for `queuePinTargets`. Types and lint clean apart from the spam-angel errors already on main.

## Not done

About 110ms per switch is left in Chromium, mostly diffuse Svelte rendering plus `deck-display` rebuilding a full-channel live query on every slug change to derive one boolean. That one needs a rethink of how deck-display and player.svelte observe the collection, so it's left for a separate pass.
